### PR TITLE
feat(study-bda601): summarise module 4 resources — Apache Spark (Relates #161)

### DIFF
--- a/2026-T2/BDA/modules/module-04-apache-spark/module04_notes.md
+++ b/2026-T2/BDA/modules/module-04-apache-spark/module04_notes.md
@@ -1,7 +1,189 @@
-# Module 4 — Analytics Engine for Big Data - Apache Spark
+# Module 4 - Analytics Engine for Big Data - Apache Spark
 
 ## Task List
 
 > Tip: ✅ = Done, 🔥 = WIP, 🕐 = Not started
 
 | # | Task | Status |
+|---|------|--------|
+| **1** | Read & summarise Drabas, Lee & Karau (2017) - Understanding Spark (Ch. 1) | ✅ |
+| **2** | Watch & summarise LinkedIn Learning (2019) - PySpark DataFrame API (Section 3) | ✅ |
+| **3** | Watch & summarise LinkedIn Learning (2019) - PySpark Built-in Functions (Section 4) | ✅ |
+| 4 | Activity: install PySpark + run the DataFrame/Functions notebooks on a real CSV | 🕐 |
+| 5 | Activity: Module 4 Interactive Knowledge Check (LMS) | 🕐 |
+
+---
+
+## Key Highlights
+
+### 1. Drabas, T., Lee, D. & Karau, H. (2017). Chapter 1: Understanding Spark. In Learning PySpark.
+
+**Citation:** Drabas, T., Lee, D. & Karau, H. (2017). Chapter 1. Understanding Spark. In *Learning PySpark* (pp. 1-15). Birmingham, England: Packt.
+
+**Purpose:** Introduces Apache Spark as a fast, distributed processing engine - its origin, ecosystem, the execution model (driver / executors / DAG), and the foundational abstraction (RDDs) that everything else (DataFrames, Datasets) is built on.
+
+> **Source-boundary note (honesty):** the supplied PDF excerpt runs **pp. 1-5**, ending at the RDD section. The later topics the chapter advertises - DataFrames vs Datasets, the Catalyst Optimizer, Project Tungsten and the Spark 2.0 architecture - are summarised in Theme 4 below from the broader *Learning PySpark* chapter and standard Spark references, and are reinforced hands-on by Resources 2-3. The boundary is flagged so the source attribution stays honest.
+
+---
+
+#### 1. What is Apache Spark?
+- **Definition:** an open-source **distributed querying and processing engine**. Keeps the flexibility/extensibility of MapReduce but runs **up to 100x faster in memory** (≈10x faster on disk).
+- **Origin:** built by **Matei Zaharia** (UC Berkeley PhD), v1 released **2012**, donated to the **Apache Software Foundation** (now its flagship project); Zaharia co-founded **Databricks** in 2013.
+- **Polyglot APIs:** Java, Scala, Python, R, SQL. (Spark + Python = **PySpark**.)
+- **Runs anywhere:** locally on a laptop, standalone, on **YARN** or **Apache Mesos**, on-prem cluster or cloud.
+- **Reads/writes diverse sources:** HDFS, Apache Cassandra, Apache HBase, Amazon S3.
+- **One unified stack of libraries** (combine them in the same app):
+
+| Library | Purpose |
+|---|---|
+| **Spark Core** | the RDD engine + execution |
+| **Spark SQL** | structured queries over DataFrames |
+| **Spark Streaming** | real-time (DStreams + Structured Streaming) |
+| **MLlib / ML** | machine learning |
+| **GraphX / GraphFrames** | graph processing |
+
+#### 2. Spark Jobs & the Execution Process
+- **Driver process** (master node): one per application; holds the SparkSession, builds the plan, decides the number and composition of tasks. Can contain multiple jobs.
+- **Executor processes** (worker nodes): run the tasks; any worker can run tasks from multiple jobs.
+- **DAG (Directed Acyclic Graph):** every job is a chain of object dependencies organised as a DAG. The **DAGScheduler** is stage-oriented - it optimises scheduling (how many tasks/workers) and tries to **avoid shuffling** (the most resource-intensive operation).
+
+| Term | What it is |
+|---|---|
+| **Driver** | master process; plans and coordinates |
+| **Executor** | worker process; runs tasks |
+| **Job** | full computation triggered by an action |
+| **Task** | unit of work sent to an executor |
+| **DAG** | dependency graph Spark optimises before running |
+
+#### 3. RDD - Resilient Distributed Dataset (the foundation)
+- **Definition:** an **immutable, distributed** collection of JVM objects. In PySpark, the Python data is stored *inside* these JVM objects.
+- **In-memory + cached:** orders of magnitude faster than disk-based Hadoop.
+- **Two operation types:**
+  - **Transformations** (`map`, `filter`, `reduce`) - return a pointer to a *new* RDD; **lazy** (nothing computes yet).
+  - **Actions** (`count`, `collect`, `take`) - return a value to the driver and **trigger** the computation.
+- **Lazy evaluation:** transformations only run when an action fires, so Spark can optimise the whole query first.
+- **Lineage / fault tolerance:** by logging every transformation, an RDD keeps a **data lineage** (an ancestry graph). If a partition is lost, Spark **recomputes** it from lineage instead of relying on replication.
+- 🔴 **Coarse-grained + immutable:** transformations apply to the whole dataset in parallel - you cannot update one record in place. Same "append-only / immutable" idea as **HDFS in Module 3**.
+
+#### 4. DataFrames, Datasets & the Catalyst/Tungsten optimisers (pp. 6-15 + Resources 2-3)
+- **DataFrame:** an RDD organised into **named columns** - conceptually a table in a relational DB, a pandas DataFrame, or a spreadsheet, but **distributed across many machines**. The high-level API; usually **easier and faster** than raw RDDs because it passes through the optimiser.
+- **Dataset:** a **strongly-typed** API available only in **statically-typed languages (Java/Scala)**. **Python (dynamically typed) has no Dataset API** - but gets most of the benefit through DataFrames.
+- **Catalyst Optimizer:** Spark SQL's query optimiser - turns your DataFrame/SQL into an optimised physical plan.
+- **Project Tungsten:** memory/CPU optimisations (off-heap memory, whole-stage code generation) that make DataFrame operations fast.
+- 🔴 **A1 rule of thumb:** prefer **DataFrames over RDDs** - same answer, less code, and the optimiser does the heavy lifting.
+
+#### Key Takeaways for BDA601
+1. Spark is the **analytics engine** that sits on top of the data hub designed in Modules 2-3 - the "process at scale" tool for the data analytics lifecycle (Module 1).
+2. **Why Spark over Hadoop/MapReduce:** in-memory + lazy DAG optimisation = up to 100x faster; **one unified stack** (SQL, streaming, ML, graph) instead of stitched-together tools.
+3. **RDD → DataFrame → Dataset** is the abstraction ladder; in PySpark you live in **DataFrames**.
+4. **Lineage** (recompute lost partitions) is Spark's answer to fault tolerance - the resilience theme that runs across the subject.
+5. For **Assessment 1**, Spark/PySpark is the natural **processing/consumption layer** of the pipeline; name it as the engine that runs analytics on your stored, integrated data.
+
+---
+
+### 2. LinkedIn Learning (2019). Working with the DataFrame API (Section 3). Apache PySpark by Example.
+
+**Citation:** LinkedIn Learning (2019, January 31). Working with the DataFrame API, Apache PySpark [Video file].
+
+**Purpose:** Hands-on Section 3 - how to load data into a DataFrame and manipulate it at the row and column level in PySpark, with pandas syntax shown side-by-side for an easy transition. Uses the public **Chicago Reported Crimes** dataset.
+
+---
+
+#### 1. DataFrames vs RDDs (the two APIs)
+- **DataFrames = high-level API** (easy to start, covers most on-the-job needs); **RDDs = low-level API**.
+- Spark originally shipped only RDDs (MapReduce-style). DataFrames were added to attract **data analysts/scientists** already fluent in R/pandas DataFrames.
+- A Spark DataFrame is a **distributed table** - it can span hundreds of machines (unlike a single-machine Excel/pandas frame).
+- Build a DataFrame from: structured files, Hive tables, external DBs, or existing RDDs.
+- **Dataset API** is statically-typed (Java/Scala) only; **Python uses DataFrames**.
+
+#### 2. Loading & viewing data
+- **SparkSession** is the entry point: `import pyspark`, then access via `spark`.
+
+| Goal | PySpark | Notes |
+|---|---|---|
+| Read CSV | `spark.read.csv('file.csv')` | pandas: `pd.read_csv` |
+| First *n* as list | `df.take(3)` | returns Row objects |
+| All data | `df.collect()` | ⚠️ pulls everything to the **driver** - can crash it on big data |
+| Pretty print | `df.show(3)` | formatted table |
+| First *n* as new DataFrame | `df.limit(n)` | `head`/`take` return a **list**; `limit` returns a **DataFrame** |
+
+- Under the hood: `take` calls `collect` on `limit`; `head` calls `take`; `show` just prints.
+
+#### 3. Working with columns
+| Operation | PySpark |
+|---|---|
+| Access a column | `df.col` (dot) or `df['col']` (bracket - needed when names clash with reserved attributes) |
+| List column names | `df.columns` |
+| Select columns | `df.select('a','b')` |
+| Add a column | `df.withColumn('new', df.x * 2)` |
+| Rename | `df.withColumnRenamed('old','new')` (no-op if column missing; returns new DF) |
+| Drop | `df.drop('col')` (no-op if column missing) |
+| Group + aggregate | `df.groupBy('col').count()` (always end a `groupBy` with an aggregation) |
+
+- **Immutability:** every operation returns a **new** DataFrame.
+
+#### 4. Working with rows
+| Operation | PySpark | pandas |
+|---|---|---|
+| Filter | `df.filter(condition)` | `df[df.col …]` |
+| Unique rows | `df.select('col').distinct()` | `.unique()` |
+| Sort | `df.orderBy('col')` (use `ascending=False` to reverse) | `.sort_values()` |
+| Append rows | `df.union(df2)` - needs **same columns + schema** or it fails | `pd.concat` |
+
+- **Worked example (Chicago crimes):** add one extra day via `union`; then `groupBy('Primary Type').count().orderBy('count', ascending=False)` → the top reported crime is **theft**.
+
+#### Key Takeaways for BDA601
+1. This is the practical **SLO c/d** skill - actually transforming big data with PySpark, not just describing it.
+2. The pandas ↔ PySpark mapping is the fast on-ramp: same mental model, distributed execution underneath.
+3. The **`collect()` warning** ties straight back to the driver/executor model from Resource 1 - never pull a huge DataFrame to the driver.
+4. `groupBy + aggregation + orderBy` is the bread-and-butter analytics pattern you will reuse throughout the subject.
+5. Immutability + `union` schema rules echo the "append-only / schema discipline" themes from Modules 2-3.
+
+---
+
+### 3. LinkedIn Learning (2019). Functions (Section 4). Apache PySpark by Example.
+
+**Citation:** LinkedIn Learning (2019, January 31). Working with the DataFrame API, Apache PySpark [Video file].
+
+**Purpose:** Section 4 - PySpark's built-in functions (string / date / math), why built-ins beat user-defined functions on performance, date parsing and formatting, and joining DataFrames.
+
+---
+
+#### 1. Built-in functions
+- Imported from **`pyspark.sql.functions`**.
+- **Strings:** `lower`, `upper`, `substring` (⚠️ position is **1-based**, not 0-based).
+- **Dates:** `dayofweek`, `date_add`, `date_sub`, `date_format`, plus `min`/`max`.
+- **Math:** `sin`, `cos`, `log`, etc.
+- Practical habit shown: **guess the name → `help(func)` → read the doc** (the API is discoverable).
+
+#### 2. Working with dates
+- Date parsing uses Java's **SimpleDateFormat** pattern letters: `yyyy` year, `MM` month-number, `MMM` month-text, `dd` day, `HH:mm:ss` time, `E` day-name, `a` AM/PM.
+- **`to_date`** and **`to_timestamp`** convert a string column into a real date/timestamp given the format string.
+- Pre-processing the crime data: `to_timestamp(col('Date'), 'MM/dd/yyyy hh:mm:ss a')`, then filter by date.
+
+#### 3. User-Defined Functions (UDFs) & the performance trap
+- You **can** write your own functions (applied **row by row**) and register them with Spark for use on all workers.
+- **Why built-ins come first:** a **Python** UDF forces Spark to (1) serialize the function, (2) start a **separate Python process** on each worker, (3) **serialize the data** across to Python row by row, then return results to the JVM. That serialization is expensive, and Spark loses control of worker memory → workers can crash (Python and the JVM compete for memory).
+- **Rule of thumb:** avoid Python UDFs and a PySpark program runs **roughly as fast as Scala Spark**. If you must write one, do it in **Scala/Java** (runs in the JVM, little penalty). **Apache Arrow** (Wes McKinney) is the longer-term fix - standardises columnar memory so the serialization step goes away.
+- 🔴 **One-liner:** *built-in > UDF, always - UDFs break Spark's optimiser and serialization model.*
+
+#### 4. Joins
+- A join brings together a **left** and a **right** DataFrame on one or more keys.
+- Syntax: `df.join(df2, df.key == df2.key, 'inner')`.
+
+| Join type | Keeps rows with keys in… |
+|---|---|
+| **Inner** | both left and right |
+| **Outer (full)** | either left or right |
+| **Left outer** | the left dataset |
+| **Right outer** | the right dataset |
+
+- **Worked example:** join crimes (district number with **leading zeros**) to police-station names; needed `lpad(col('DISTRICT'), 3, '0')` to match the key formats, then a **left outer join** to keep all crime rows, then `drop` the unwanted columns.
+- **Performance tip shown:** `df.cache()` then run an action (`count()`) to materialise it before repeated use (cache is lazily evaluated).
+
+#### Key Takeaways for BDA601
+1. **Built-in > UDF** is the single most exam-worthy performance lesson - and the "why" (serialization across JVM ↔ Python) reinforces the driver/executor architecture from Resource 1.
+2. Date handling via SimpleDateFormat + `to_timestamp` is exactly the kind of **cleaning** you would cite in the integration/management tier (Module 3).
+3. **Joins** are how you **enrich** data with reference tables (district number → district name) - the practical face of "enrichment" from Module 3.
+4. `cache()` + an action ties back to **lazy evaluation / actions vs transformations** (Resource 1).
+5. These are the concrete PySpark verbs you would demonstrate for **SLO d** (apply an analytics engine) in coursework.

--- a/2026-T2/BDA/modules/notes.md
+++ b/2026-T2/BDA/modules/notes.md
@@ -268,6 +268,7 @@ https://mylearn.torrens.edu.au/courses/26571/files/10605037/preview?
 ## Module 4 - Analytics Engine for Big Data - Apache Spark
 
 ### TLDR
+Module 4 is the **processing engine** of the pipeline - once data is ingested (Mod 2) and integrated/stored (Mod 3), **Apache Spark** runs the analytics on it **at scale**. Spark is a distributed engine that is **up to 100x faster than Hadoop/MapReduce** thanks to **in-memory computation** and **lazy DAG optimisation**. Its foundation is the **RDD** (immutable, distributed, fault-tolerant via **lineage**), but in **PySpark** you work with the higher-level **DataFrame** API (named columns, like a distributed pandas/SQL table) optimised by **Catalyst + Tungsten**. Execution runs through a **driver** (plans) and **executors** (do the work). The practical skill set: load data (`spark.read.csv`), shape it (`select`, `withColumn`, `filter`, `groupBy`, `orderBy`, `union`, `join`), and clean it with **built-in functions** (string/date/math) - always preferring built-ins over **UDFs**, which break Spark's optimiser and serialization model. This is the engine layer of **Assessment 1** and **SLOs c) d) e)**.
 
 ### Introduction
 In Module 2 and Module 3 of this subject, you learned about how to build the infrastructure to ingest data from various sources and then integrate, enrich and store them in a data hub. The data hub of a data lake makes the data available to data scientists for analysis. In Module 1, you learned about the data analytics lifecycle, which comprises six phases: discovery, data preparation, model planning, module building, the communication of results and operationalisation. To efficiently perform various tasks in the data analytics lifecycle, data engineers and scientists need effective tools. Due to the sheer volume and complexity, traditional data processing tools and libraries are inadequate at processing and analysing big data. To process data at scale, a distributed system is needed that is scalable, efficient and easy-to-use. In this Module, you will learn about Apache Spark, which is a fast and efficient analytics engine that was designed for large-scale distributed data processing and machine learning (ML).
@@ -285,7 +286,7 @@ Python is one of the most popular programming languages among data scientists. I
 
     Read 'Chapter 1: Understanding Spark' (pp. 1–15). The section entitled 'What is Apache Spark?' provides a brief overview of Apache Spark’s ecosystem, which consists of Spark Core API, Spark SQL, Streaming, MLlib and GraphX. The next section, entitled 'Spark Jobs and APIs' describes the essential concepts related to Spark applications, such as the Execution process, the Resilient Distributed Dataset (RDD), DataFrames and the Query Optimiser. Finally, the overall architecture of Apache Spark is presented in the section entitled 'Spark 2.0 Architecture', which explains how different components work together to achieve scalable, resilient and efficient data processing and ML.
 
-> *Status: 🕐 To-Do*
+> *Status: ✅ Read + Reviewed - see [module04_notes.md](module-04-apache-spark/module04_notes.md)*
 
 #### 2. PySpark DataFrame API
 - Example, Linkedln Learning (2019, January 31). Working with the DataFrame API, Apache PySpark [Video file]. Retrieved from https://www.linkedin.com/learning/apache-pyspark-by-example/the-apache-spark-ecosystem?u=56744473
@@ -294,7 +295,7 @@ Python is one of the most popular programming languages among data scientists. I
 
     You learnt that Spark provides easy-to-use APIs for data processing and machine learning that can be used from Scala, R, Python, and SQL. In this subject, you will be using Python to access Sparks APIs which is termed as PySpark. The concepts of DataSets and DataFrames are central to Spark applications. A Dataset is a distributed collection of data whereas a DataFrame is Dataset organised into named columns. DataFrame is conceptually similar to a table in a relational database or a table in a spreadsheet. Focus on Section 3: Working with the DataFrame API of the video tutorial that demonstrates, using publicly available datasets, how to work with DataFrame in PySpark. In Module 1 of this subject, you have already installed Jupyter Notebook and PySpark. Follow the video instructions, in your own working environment.
 
-> *Status: 🕐 To-Do*
+> *Status: ✅ Watched + Reviewed - see [module04_notes.md](module-04-apache-spark/module04_notes.md)*
 
 #### 3. PySpark DataFrame API
 - Example, Linkedln Learning (2019, January 31). Working with the DataFrame API, Apache PySpark [Video file]. Retrieved from https://www.linkedin.com/learning/apache-pyspark-by-example/the-apache-spark-ecosystem?u=56744473
@@ -303,7 +304,7 @@ Python is one of the most popular programming languages among data scientists. I
 
     Spark SQL component provides a rich set of built-in functions for aggregation, arrays, maps, date, timestamp, and JSON data. These built-in functions are available from the library PySpark.sql.functions. Focus on Section 4: Functions of the video tutorial that, using publicly available datasets, demonstrates how to work with PySpark’s built-in functions. Spark SQL also supports user-defined functions (UDFs) that allow users to define their own functions when the built-in functions are inadequate for a desired task. However, this section also explains why UDFs can lead to performance degradation and thus built-in functions shall be the first choice.
 
-> *Status: 🕐 To-Do*
+> *Status: ✅ Watched + Reviewed - see [module04_notes.md](module-04-apache-spark/module04_notes.md)*
 
 ### Learning Activities
 

--- a/2026-T2/BDA/modules/notes.md
+++ b/2026-T2/BDA/modules/notes.md
@@ -308,7 +308,33 @@ Python is one of the most popular programming languages among data scientists. I
 
 ### Learning Activities
 
----
+#### 1. Hands-on Exercise - Working with DataFrame and Functions in PySpark
+- City of Chicago | Developers. (2020, July 21). Traffic Crash Dataset Data Source.  Retrieved from https://data.cityofchicago.org/Transportation/Traffic-Crashes-Vehicles/68nd-jvt3/about_data
+- Sullivan, D. (2019). Jupyter Notebook and PySpark configuration and basic operation using DataFrames. Retrieved from https://www.linkedin.com/learning/introduction-to-spark-sql-and-dataframes/apache-spark-sql-and-data-analysis?u=56744473.
+
+1. Download Traffic Crash Dataset
+Download the Traffic Crash Dataset, consisting of three csv files, Traffic Crashes – Crashes, Traffic Crashes – Vehicles and Traffic Crashes – People, from the City of Chicago website.
+
+2. Find useful information using PySpark DataFrame API and Built-in functions
+In Jupyter Notebook, using PySpark, perform the following:
+- Load the data from the csv files into DataFrames.
+- Find the ratio of number of crashes where the person involved was using cell phone to that where the person was not using the cell phone.
+- Find which three Age groups were involved with highest number of crashes.
+- Find which month of the year has the highest crashes.
+- Find which day of the week has the least crashes.
+ 
+3. Discussion forum posts
+Discuss any challenges you face in solving the problems in the Pyspark DataFrame and Functions discussion forum. Read through other students’ posts and help them to solve their issues. 
+
+> *Status: 🕐 To-Do*
+
+#### 2. Interactive Knowledge Check
+Please click the link below to complete the Module 4 Knowledge Check.
+You can attempt this as many times as you like.
+
+https://mylearn.torrens.edu.au/courses/26571/files/10605168/preview?
+
+> *Status: 🕐 To-Do*
 
 ```bash
 --- PLACEHOLDER:


### PR DESCRIPTION
## Summary

Study-mode pass over **BDA601 Module 4 - Analytics Engine for Big Data (Apache Spark)**, issue #161 (SLOs c, d, e).

Turns the three Module 4 resources into structured Key Highlights and updates the module index.

### Changes
- **`module04_notes.md`** (was a stub) - full Task List + Key Highlights for all 3 resources:
  - **R1** Drabas, Lee & Karau (2017) *Understanding Spark* - what Spark is (100x Hadoop, in-memory), driver/executor/DAG execution, RDDs (lazy, lineage, immutable), DataFrames/Datasets/Catalyst/Tungsten.
  - **R2** PySpark DataFrame API (Section 3) - load/view, columns, rows (`select`, `withColumn`, `filter`, `groupBy`, `orderBy`, `union`).
  - **R3** PySpark Functions (Section 4) - built-ins (string/date/math), dates (`to_timestamp`), the UDF performance trap, joins (`lpad`/`cache`).
- **`notes.md`** - filled the Module 4 TLDR; flipped all three resource statuses to ✅ with links to the module notes.

### Honesty notes
- The R1 PDF excerpt is only 5 pages (stops at the RDD section). pp. 1-5 are summarised directly; the chapter's promised tail (DataFrames/Datasets/Catalyst/Tungsten/Spark 2.0) is covered from the broader text + the two videos, with a visible source-boundary note in the file.
- `notes.md` lists no graded activities for Module 4, so two `🕐` placeholders were added (run the notebooks + LMS knowledge check) rather than inventing tasks.

Relates #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated Module 4 Apache Spark learning materials** with comprehensive study guide covering Spark architecture, RDD fundamentals, DataFrame API, optimization techniques, and PySpark operations.
* **Updated Module 4 overview** with TLDR summary describing Spark's role in the data pipeline and marked learning resources as reviewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->