### PR TITLE
A3: Colab self-configuration + standardized title block

### DIFF
--- a/2026-T2/BDA/assignments/Assessment3/notebook/BDA601FariaLuis_Assessment3.ipynb
+++ b/2026-T2/BDA/assignments/Assessment3/notebook/BDA601FariaLuis_Assessment3.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "305dfecd",
+   "id": "5fd47ee6",
    "metadata": {},
    "source": [
     "# BDA601 Assessment 3 - Model Evaluation\n",
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bb07e25",
+   "id": "0a9eb9c5",
    "metadata": {},
    "source": [
     "## How to run this notebook\n",
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab9d8aeb",
+   "id": "68ebdfb9",
    "metadata": {},
    "source": [
     "## 0. Setup, environment checks and Spark session\n",
@@ -77,13 +77,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "43285036",
+   "id": "30fe736b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:45.472087Z",
-     "iopub.status.busy": "2026-08-10T23:11:45.471728Z",
-     "iopub.status.idle": "2026-08-10T23:11:46.318813Z",
-     "shell.execute_reply": "2026-08-10T23:11:46.318342Z"
+     "iopub.execute_input": "2026-08-10T23:14:44.425790Z",
+     "iopub.status.busy": "2026-08-10T23:14:44.425637Z",
+     "iopub.status.idle": "2026-08-10T23:14:45.451135Z",
+     "shell.execute_reply": "2026-08-10T23:14:45.450583Z"
     }
    },
    "outputs": [
@@ -98,7 +98,7 @@
     }
    ],
    "source": [
-    "import os, sys, json, subprocess, warnings\n",
+    "import os, sys, json, re, subprocess, warnings\n",
     "from pathlib import Path\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")\n",
@@ -116,21 +116,34 @@
     "        raise SetupError(message)\n",
     "\n",
     "\n",
-    "def _java_runs(home):\n",
-    "    '''A JAVA_HOME candidate is only valid if `bin/java` actually executes - a directory\n",
-    "    existing on disk is not enough (a broken or partial install still passes that check).'''\n",
+    "def _java_version_ok(home):\n",
+    "    '''A JAVA_HOME candidate is only valid if `bin/java` runs AND reports version 8 or 11 -\n",
+    "    Spark 3.5 supports neither older nor newer JDKs, and a directory merely existing on disk,\n",
+    "    or a working-but-wrong-version `java`, both pass a shallower check and fail later with an\n",
+    "    opaque JAVA_GATEWAY_EXITED when Spark actually tries to start.'''\n",
     "    java_bin = Path(home) / \"bin\" / \"java\"\n",
     "    try:\n",
-    "        return subprocess.run([str(java_bin), \"-version\"], capture_output=True,\n",
-    "                               text=True, timeout=10).returncode == 0\n",
+    "        result = subprocess.run([str(java_bin), \"-version\"], capture_output=True,\n",
+    "                                text=True, timeout=10)\n",
     "    except (OSError, subprocess.SubprocessError):\n",
     "        return False\n",
+    "    if result.returncode != 0:\n",
+    "        return False\n",
+    "    # `java -version` writes to stderr by long-standing convention (stdout on some vendors).\n",
+    "    output = result.stderr or result.stdout\n",
+    "    match = re.search(r'version \"(\\d+)(?:\\.(\\d+))?', output)\n",
+    "    if not match:\n",
+    "        return False\n",
+    "    major = int(match.group(1))\n",
+    "    if major == 1:  # legacy \"1.8.0_xxx\" scheme used by Java 8 and earlier\n",
+    "        major = int(match.group(2)) if match.group(2) else 0\n",
+    "    return major in (8, 11)\n",
     "\n",
     "\n",
     "def find_java_home():\n",
     "    '''Locate a working Java 8/11 installation. Spark 3.5 will not start without one.'''\n",
     "    env = os.environ.get(\"JAVA_HOME\")\n",
-    "    if env and _java_runs(env):\n",
+    "    if env and _java_version_ok(env):\n",
     "        return env\n",
     "    # macOS ships a helper that reports installed JVMs.\n",
     "    for version in (\"1.8\", \"11\"):\n",
@@ -149,7 +162,7 @@
     "    candidates += sorted(str(p) for p in Path(\"/usr/lib/jvm\").glob(\"java-8-openjdk-*\")) \\\n",
     "        if Path(\"/usr/lib/jvm\").exists() else []\n",
     "    for candidate in candidates:\n",
-    "        if _java_runs(candidate):\n",
+    "        if _java_version_ok(candidate):\n",
     "            return candidate\n",
     "    return None\n",
     "\n",
@@ -233,13 +246,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f3eef67c",
+   "id": "31274c79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:46.320026Z",
-     "iopub.status.busy": "2026-08-10T23:11:46.319900Z",
-     "iopub.status.idle": "2026-08-10T23:11:48.264594Z",
-     "shell.execute_reply": "2026-08-10T23:11:48.264094Z"
+     "iopub.execute_input": "2026-08-10T23:14:45.458853Z",
+     "iopub.status.busy": "2026-08-10T23:14:45.458485Z",
+     "iopub.status.idle": "2026-08-10T23:14:48.215021Z",
+     "shell.execute_reply": "2026-08-10T23:14:48.214385Z"
     }
    },
    "outputs": [
@@ -247,8 +260,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "26/08/11 09:11:47 WARN Utils: Your hostname, Luiss-MacBook-Pro.local resolves to a loopback address: 127.0.0.1; using 192.168.0.3 instead (on interface en0)\n",
-      "26/08/11 09:11:47 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n"
+      "26/08/11 09:14:46 WARN Utils: Your hostname, Luiss-MacBook-Pro.local resolves to a loopback address: 127.0.0.1; using 192.168.0.3 instead (on interface en0)\n",
+      "26/08/11 09:14:46 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n"
      ]
     },
     {
@@ -256,8 +269,14 @@
      "output_type": "stream",
      "text": [
       "Setting default log level to \"WARN\".\n",
-      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
-      "26/08/11 09:11:47 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "26/08/11 09:14:47 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
      ]
     },
     {
@@ -288,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df570cdd",
+   "id": "8137d6f3",
    "metadata": {},
    "source": [
     "## 1. Problem statement\n",
@@ -306,7 +325,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c10b525c",
+   "id": "ccfe3164",
    "metadata": {},
    "source": [
     "## 2. Dataset preparation\n",
@@ -324,13 +343,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "be3ca10d",
+   "id": "5c368296",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:48.266329Z",
-     "iopub.status.busy": "2026-08-10T23:11:48.266235Z",
-     "iopub.status.idle": "2026-08-10T23:11:48.431623Z",
-     "shell.execute_reply": "2026-08-10T23:11:48.431223Z"
+     "iopub.execute_input": "2026-08-10T23:14:48.216944Z",
+     "iopub.status.busy": "2026-08-10T23:14:48.216830Z",
+     "iopub.status.idle": "2026-08-10T23:14:48.534855Z",
+     "shell.execute_reply": "2026-08-10T23:14:48.534358Z"
     }
    },
    "outputs": [
@@ -398,13 +417,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "570c2681",
+   "id": "9e07c388",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:48.432605Z",
-     "iopub.status.busy": "2026-08-10T23:11:48.432542Z",
-     "iopub.status.idle": "2026-08-10T23:11:48.576602Z",
-     "shell.execute_reply": "2026-08-10T23:11:48.576286Z"
+     "iopub.execute_input": "2026-08-10T23:14:48.539483Z",
+     "iopub.status.busy": "2026-08-10T23:14:48.539361Z",
+     "iopub.status.idle": "2026-08-10T23:14:48.699412Z",
+     "shell.execute_reply": "2026-08-10T23:14:48.698995Z"
     }
    },
    "outputs": [
@@ -432,7 +451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3c74180",
+   "id": "3095d230",
    "metadata": {},
    "source": [
     "## 3. Predictive modelling - linear regression per country\n",
@@ -453,24 +472,16 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "405cb48d",
+   "id": "5501a2df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:48.577870Z",
-     "iopub.status.busy": "2026-08-10T23:11:48.577808Z",
-     "iopub.status.idle": "2026-08-10T23:11:54.304247Z",
-     "shell.execute_reply": "2026-08-10T23:11:54.303656Z"
+     "iopub.execute_input": "2026-08-10T23:14:48.700629Z",
+     "iopub.status.busy": "2026-08-10T23:14:48.700550Z",
+     "iopub.status.idle": "2026-08-10T23:14:58.230984Z",
+     "shell.execute_reply": "2026-08-10T23:14:58.229394Z"
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "[Stage 0:>                                                          (0 + 0) / 8]\r"
-     ]
-    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -483,6 +494,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "                                                                                \r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[Stage 2:>                                                          (0 + 8) / 8]\r",
       "\r",
       "                                                                                \r"
      ]
@@ -531,13 +552,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "c3a6eeaf",
+   "id": "fdf6f32b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:54.306814Z",
-     "iopub.status.busy": "2026-08-10T23:11:54.306726Z",
-     "iopub.status.idle": "2026-08-10T23:11:54.607936Z",
-     "shell.execute_reply": "2026-08-10T23:11:54.607513Z"
+     "iopub.execute_input": "2026-08-10T23:14:58.246014Z",
+     "iopub.status.busy": "2026-08-10T23:14:58.245844Z",
+     "iopub.status.idle": "2026-08-10T23:14:58.666558Z",
+     "shell.execute_reply": "2026-08-10T23:14:58.666147Z"
     }
    },
    "outputs": [
@@ -570,13 +591,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "0ec9b0c5",
+   "id": "aad18d16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:54.609156Z",
-     "iopub.status.busy": "2026-08-10T23:11:54.609031Z",
-     "iopub.status.idle": "2026-08-10T23:11:54.840541Z",
-     "shell.execute_reply": "2026-08-10T23:11:54.840150Z"
+     "iopub.execute_input": "2026-08-10T23:14:58.669489Z",
+     "iopub.status.busy": "2026-08-10T23:14:58.669393Z",
+     "iopub.status.idle": "2026-08-10T23:14:58.960792Z",
+     "shell.execute_reply": "2026-08-10T23:14:58.960434Z"
     }
    },
    "outputs": [
@@ -622,7 +643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab43ed8a",
+   "id": "2fd1d768",
    "metadata": {},
    "source": [
     "## 4. Clustering - K-Means on the most volatile country\n",
@@ -640,13 +661,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "858e9a7d",
+   "id": "585fdcfc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:54.842100Z",
-     "iopub.status.busy": "2026-08-10T23:11:54.842005Z",
-     "iopub.status.idle": "2026-08-10T23:11:59.534041Z",
-     "shell.execute_reply": "2026-08-10T23:11:59.533170Z"
+     "iopub.execute_input": "2026-08-10T23:14:58.962354Z",
+     "iopub.status.busy": "2026-08-10T23:14:58.962266Z",
+     "iopub.status.idle": "2026-08-10T23:15:04.548723Z",
+     "shell.execute_reply": "2026-08-10T23:15:04.548220Z"
     }
    },
    "outputs": [
@@ -662,9 +683,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CodeCache: size=131072Kb used=43757Kb max_used=43757Kb free=87314Kb\n",
-      " bounds [0x00000001020a4000, 0x0000000104ba4000, 0x000000010a0a4000]\n",
-      " total_blobs=16474 nmethods=14684 adapters=1700\n",
+      "CodeCache: size=131072Kb used=37631Kb max_used=37656Kb free=93440Kb\n",
+      " bounds [0x00000001029c0000, 0x0000000104ec0000, 0x000000010a9c0000]\n",
+      " total_blobs=14819 nmethods=13030 adapters=1700\n",
       " compilation: disabled (not enough contiguous free space left)\n"
      ]
     },
@@ -736,13 +757,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "5075ca6e",
+   "id": "8b64f9c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:59.536810Z",
-     "iopub.status.busy": "2026-08-10T23:11:59.536670Z",
-     "iopub.status.idle": "2026-08-10T23:11:59.729326Z",
-     "shell.execute_reply": "2026-08-10T23:11:59.728916Z"
+     "iopub.execute_input": "2026-08-10T23:15:04.552024Z",
+     "iopub.status.busy": "2026-08-10T23:15:04.551875Z",
+     "iopub.status.idle": "2026-08-10T23:15:04.749692Z",
+     "shell.execute_reply": "2026-08-10T23:15:04.749249Z"
     }
    },
    "outputs": [
@@ -777,13 +798,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "ee875f63",
+   "id": "9f33fb07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:59.731553Z",
-     "iopub.status.busy": "2026-08-10T23:11:59.731473Z",
-     "iopub.status.idle": "2026-08-10T23:11:59.938419Z",
-     "shell.execute_reply": "2026-08-10T23:11:59.938091Z"
+     "iopub.execute_input": "2026-08-10T23:15:04.750911Z",
+     "iopub.status.busy": "2026-08-10T23:15:04.750823Z",
+     "iopub.status.idle": "2026-08-10T23:15:05.054499Z",
+     "shell.execute_reply": "2026-08-10T23:15:05.054081Z"
     }
    },
    "outputs": [
@@ -832,7 +853,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64050b1c",
+   "id": "eaaee4fc",
    "metadata": {},
    "source": [
     "## 5. Graph analytics - the focal country and its neighbours\n",
@@ -850,13 +871,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "1f85c636",
+   "id": "c9e4f61d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:11:59.940099Z",
-     "iopub.status.busy": "2026-08-10T23:11:59.940021Z",
-     "iopub.status.idle": "2026-08-10T23:12:00.125776Z",
-     "shell.execute_reply": "2026-08-10T23:12:00.125358Z"
+     "iopub.execute_input": "2026-08-10T23:15:05.055860Z",
+     "iopub.status.busy": "2026-08-10T23:15:05.055784Z",
+     "iopub.status.idle": "2026-08-10T23:15:05.306741Z",
+     "shell.execute_reply": "2026-08-10T23:15:05.306342Z"
     }
    },
    "outputs": [
@@ -864,10 +885,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Focal: US | neighbours: ['Canada', 'Mexico']\n",
+      "Focal: US | neighbours: ['Canada', 'Mexico']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "neighbour  corr  ci_low  ci_high  weeks\n",
       "   Canada 0.848   0.264    0.920    164\n",
-      "   Mexico 0.697   0.459    0.819    164\n"
+      "   Mexico 0.697   0.459    0.819    164"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -934,13 +968,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "a4dc2ab7",
+   "id": "a821d161",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:12:00.126972Z",
-     "iopub.status.busy": "2026-08-10T23:12:00.126894Z",
-     "iopub.status.idle": "2026-08-10T23:12:00.206261Z",
-     "shell.execute_reply": "2026-08-10T23:12:00.205786Z"
+     "iopub.execute_input": "2026-08-10T23:15:05.308186Z",
+     "iopub.status.busy": "2026-08-10T23:15:05.308099Z",
+     "iopub.status.idle": "2026-08-10T23:15:05.403271Z",
+     "shell.execute_reply": "2026-08-10T23:15:05.402679Z"
     }
    },
    "outputs": [
@@ -989,7 +1023,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee64c82c",
+   "id": "03c54094",
    "metadata": {},
    "source": [
     "## 6. Lead-lag analysis - who can actually be warned?\n",
@@ -1013,13 +1047,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "a74f3ee7",
+   "id": "e9164fee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:12:00.207636Z",
-     "iopub.status.busy": "2026-08-10T23:12:00.207567Z",
-     "iopub.status.idle": "2026-08-10T23:12:00.225127Z",
-     "shell.execute_reply": "2026-08-10T23:12:00.224784Z"
+     "iopub.execute_input": "2026-08-10T23:15:05.404549Z",
+     "iopub.status.busy": "2026-08-10T23:15:05.404457Z",
+     "iopub.status.idle": "2026-08-10T23:15:05.425725Z",
+     "shell.execute_reply": "2026-08-10T23:15:05.425331Z"
     }
    },
    "outputs": [
@@ -1081,13 +1115,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "c6f7a4db",
+   "id": "3825d38d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:12:00.226252Z",
-     "iopub.status.busy": "2026-08-10T23:12:00.226189Z",
-     "iopub.status.idle": "2026-08-10T23:12:00.381671Z",
-     "shell.execute_reply": "2026-08-10T23:12:00.381311Z"
+     "iopub.execute_input": "2026-08-10T23:15:05.426805Z",
+     "iopub.status.busy": "2026-08-10T23:15:05.426738Z",
+     "iopub.status.idle": "2026-08-10T23:15:05.848173Z",
+     "shell.execute_reply": "2026-08-10T23:15:05.847762Z"
     }
    },
    "outputs": [
@@ -1134,7 +1168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba953261",
+   "id": "a910242b",
    "metadata": {},
    "source": [
     "## 7. Visualisation - the story in one frame\n",
@@ -1147,13 +1181,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "213dd1fb",
+   "id": "800d1eb5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:12:00.383215Z",
-     "iopub.status.busy": "2026-08-10T23:12:00.383133Z",
-     "iopub.status.idle": "2026-08-10T23:12:00.670552Z",
-     "shell.execute_reply": "2026-08-10T23:12:00.670110Z"
+     "iopub.execute_input": "2026-08-10T23:15:05.849801Z",
+     "iopub.status.busy": "2026-08-10T23:15:05.849696Z",
+     "iopub.status.idle": "2026-08-10T23:15:06.134123Z",
+     "shell.execute_reply": "2026-08-10T23:15:06.133590Z"
     }
    },
    "outputs": [
@@ -1198,13 +1232,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "db42efcd",
+   "id": "5f088a22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:12:00.671862Z",
-     "iopub.status.busy": "2026-08-10T23:12:00.671761Z",
-     "iopub.status.idle": "2026-08-10T23:12:00.677585Z",
-     "shell.execute_reply": "2026-08-10T23:12:00.677238Z"
+     "iopub.execute_input": "2026-08-10T23:15:06.135289Z",
+     "iopub.status.busy": "2026-08-10T23:15:06.135202Z",
+     "iopub.status.idle": "2026-08-10T23:15:06.141029Z",
+     "shell.execute_reply": "2026-08-10T23:15:06.140613Z"
     }
    },
    "outputs": [
@@ -1267,7 +1301,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f12a05a",
+   "id": "ea115af0",
    "metadata": {},
    "source": [
     "## 8. Conclusion and recommendation\n",
@@ -1296,7 +1330,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fbafea1",
+   "id": "9d5d8dc7",
    "metadata": {},
    "source": [
     "## 9. Limitations\n",
@@ -1323,7 +1357,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8227abf",
+   "id": "6cbc1542",
    "metadata": {},
    "source": [
     "## Academic Integrity Declaration\n",
@@ -1370,7 +1404,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffb107fb",
+   "id": "337ca8a2",
    "metadata": {},
    "source": [
     "## Appendix A - Glossary\n",
@@ -1402,7 +1436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7da23b77",
+   "id": "45a5e2cb",
    "metadata": {},
    "source": [
     "## Appendix B - Analytical decision log\n",
@@ -1472,13 +1506,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "bd600672",
+   "id": "db54aeac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:12:00.678750Z",
-     "iopub.status.busy": "2026-08-10T23:12:00.678689Z",
-     "iopub.status.idle": "2026-08-10T23:12:01.538482Z",
-     "shell.execute_reply": "2026-08-10T23:12:01.537076Z"
+     "iopub.execute_input": "2026-08-10T23:15:06.142730Z",
+     "iopub.status.busy": "2026-08-10T23:15:06.142644Z",
+     "iopub.status.idle": "2026-08-10T23:15:06.650542Z",
+     "shell.execute_reply": "2026-08-10T23:15:06.649374Z"
     }
    },
    "outputs": [

--- a/2026-T2/BDA/assignments/Assessment3/notebook/BDA601FariaLuis_Assessment3.ipynb
+++ b/2026-T2/BDA/assignments/Assessment3/notebook/BDA601FariaLuis_Assessment3.ipynb
@@ -2,17 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "102c3fbf",
+   "id": "36d20791",
    "metadata": {},
    "source": [
     "# BDA601 Assessment 3 - Model Evaluation\n",
-    "### COVID-19 analytics: regression, clustering and graph analytics on the Johns Hopkins time series\n",
     "\n",
-    "| Item | Detail |\n",
+    "## COVID-19 Analytics: Regression, Clustering and Graph Analytics on the Johns Hopkins Time Series\n",
+    "\n",
+    "*BDA601 Assessment 3 - Model Evaluation*\n",
+    "\n",
+    "Torrens University Australia\n",
+    "\n",
+    "- **Student:** Luis Guilherme de Barros Andrade Faria - A00187785\n",
+    "- **Subject:** Big Data and Analytics (BDA601)\n",
+    "- **Lecturer:** Dr. Chen Zhan\n",
+    "- **Assessment:** 3\n",
+    "- **Date:** August 2026\n",
+    "\n",
+    "| Field | Scope |\n",
     "|---|---|\n",
-    "| Student | Luis Faria |\n",
-    "| Subject | BDA601 - Big Data and Analytics |\n",
-    "| Assessment | Assessment 3 - Model Evaluation (40%) |\n",
     "| Dataset | JHU CSSE confirmed-cases global time series (22 Jan 2020 - 9 Mar 2023) |\n",
     "| Engine | Apache Spark MLlib (`pyspark.ml`) for regression + K-Means; networkx for graph |\n",
     "| Deliverables | Source code (this notebook) + video presentation + PDF slides |\n",
@@ -24,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "140fc54c",
+   "id": "a554fb9b",
    "metadata": {},
    "source": [
     "## How to run this notebook\n",
@@ -34,7 +42,7 @@
     "needed: `JAVA_HOME` is detected automatically in Section 0, and every path is resolved relative to\n",
     "this notebook.\n",
     "\n",
-    "**Steps**\n",
+    "**Steps (local)**\n",
     "\n",
     "1. Place `time_series_covid19_confirmed_global.csv` in the `dataset/` folder next to this notebook's\n",
     "   parent (that is, `Assessment3/dataset/`). The file is the *confirmed cases* global time series from\n",
@@ -43,6 +51,12 @@
     "2. Run all cells top to bottom (`Kernel -> Restart & Run All`). Total runtime is about 1-2 minutes.\n",
     "3. Outputs are written automatically to `outputs/figures/*.png` and `outputs/metrics.json`.\n",
     "\n",
+    "**Google Colab** - if this notebook is opened on its own (no `dataset/` folder present), Section 0\n",
+    "detects Colab and self-configures: it `pip install`s `pyspark`, `apt-get install`s OpenJDK if no JVM is\n",
+    "present, and downloads the same JHU CSSE file from its canonical GitHub source (byte-identical to the\n",
+    "copy in this repo's `dataset/` folder) into a fresh working folder under `/content`. No manual upload\n",
+    "or setup step is required in Colab either.\n",
+    "\n",
     "**If something goes wrong** - each stage validates its inputs and raises a message that names the\n",
     "problem and the fix (missing dataset, missing Java, unknown country, insufficient overlap). Read the\n",
     "message rather than the traceback: it tells you what to correct."
@@ -50,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10fccaeb",
+   "id": "dbd03261",
    "metadata": {},
    "source": [
     "## 0. Setup, environment checks and Spark session\n",
@@ -63,13 +77,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "4c1bf99e",
+   "id": "9218e7e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:02.856300Z",
-     "iopub.status.busy": "2026-08-03T20:19:02.856047Z",
-     "iopub.status.idle": "2026-08-03T20:19:04.144541Z",
-     "shell.execute_reply": "2026-08-03T20:19:04.144110Z"
+     "iopub.execute_input": "2026-08-10T23:07:31.973498Z",
+     "iopub.status.busy": "2026-08-10T23:07:31.973138Z",
+     "iopub.status.idle": "2026-08-10T23:07:34.489582Z",
+     "shell.execute_reply": "2026-08-10T23:07:34.489120Z"
     }
    },
    "outputs": [
@@ -88,6 +102,8 @@
     "from pathlib import Path\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "IN_COLAB = \"google.colab\" in sys.modules\n",
     "\n",
     "\n",
     "class SetupError(RuntimeError):\n",
@@ -122,6 +138,18 @@
     "    return None\n",
     "\n",
     "\n",
+    "if IN_COLAB:\n",
+    "    # Colab's base image has neither pyspark nor a JVM. Both are one-off, silent installs -\n",
+    "    # this is the expected starting state there, not a misconfiguration to blame the user for.\n",
+    "    try:\n",
+    "        import pyspark  # noqa: F401\n",
+    "    except ImportError:\n",
+    "        print(\"Installing pyspark for Colab (one-off, ~20s)...\")\n",
+    "        subprocess.run([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"pyspark==3.5.3\"], check=True)\n",
+    "    if find_java_home() is None:\n",
+    "        print(\"Installing OpenJDK 11 for Colab (one-off, ~15s)...\")\n",
+    "        subprocess.run([\"apt-get\", \"install\", \"-y\", \"-qq\", \"openjdk-11-jdk-headless\"], check=False)\n",
+    "\n",
     "os.environ[\"PYSPARK_PYTHON\"] = sys.executable\n",
     "os.environ[\"PYSPARK_DRIVER_PYTHON\"] = sys.executable\n",
     "\n",
@@ -148,6 +176,23 @@
     "DATA = ASSESS / \"dataset\" / \"time_series_covid19_confirmed_global.csv\"\n",
     "OUT_DIR = ASSESS / \"outputs\"\n",
     "FIG_DIR = OUT_DIR / \"figures\"\n",
+    "\n",
+    "if not DATA.exists() and IN_COLAB:\n",
+    "    # A bare notebook opened in Colab has none of this repo's folders - the local fallback\n",
+    "    # above resolves to nowhere sensible. Recreate the expected layout under /content and\n",
+    "    # fetch the same file from its canonical GitHub source (verified byte-identical, via\n",
+    "    # sha256, to the copy tracked in this repo's dataset/ folder).\n",
+    "    print(\"Dataset not found locally - downloading JHU CSSE confirmed-cases series for Colab...\")\n",
+    "    import urllib.request\n",
+    "    ASSESS = Path(\"/content/BDA601_Assessment3\")\n",
+    "    DATA = ASSESS / \"dataset\" / \"time_series_covid19_confirmed_global.csv\"\n",
+    "    OUT_DIR = ASSESS / \"outputs\"\n",
+    "    FIG_DIR = OUT_DIR / \"figures\"\n",
+    "    DATA.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    urllib.request.urlretrieve(\n",
+    "        \"https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/\"\n",
+    "        \"csse_covid_19_time_series/time_series_covid19_confirmed_global.csv\", DATA)\n",
+    "\n",
     "FIG_DIR.mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "require(DATA.exists(),\n",
@@ -164,13 +209,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "02f1086c",
+   "id": "03743d8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:04.146399Z",
-     "iopub.status.busy": "2026-08-03T20:19:04.146237Z",
-     "iopub.status.idle": "2026-08-03T20:19:06.467305Z",
-     "shell.execute_reply": "2026-08-03T20:19:06.466837Z"
+     "iopub.execute_input": "2026-08-10T23:07:34.492907Z",
+     "iopub.status.busy": "2026-08-10T23:07:34.492755Z",
+     "iopub.status.idle": "2026-08-10T23:07:37.071374Z",
+     "shell.execute_reply": "2026-08-10T23:07:37.070501Z"
     }
    },
    "outputs": [
@@ -178,8 +223,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "26/08/04 06:19:05 WARN Utils: Your hostname, Luiss-MacBook-Pro.local resolves to a loopback address: 127.0.0.1; using 192.168.0.3 instead (on interface en0)\n",
-      "26/08/04 06:19:05 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n"
+      "26/08/11 09:07:36 WARN Utils: Your hostname, Luiss-MacBook-Pro.local resolves to a loopback address: 127.0.0.1; using 192.168.0.3 instead (on interface en0)\n",
+      "26/08/11 09:07:36 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n"
      ]
     },
     {
@@ -188,7 +233,7 @@
      "text": [
       "Setting default log level to \"WARN\".\n",
       "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
-      "26/08/04 06:19:05 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+      "26/08/11 09:07:36 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
      ]
     },
     {
@@ -219,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d42eb958",
+   "id": "74ad5075",
    "metadata": {},
    "source": [
     "## 1. Problem statement\n",
@@ -237,7 +282,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd691ba4",
+   "id": "9404ccb3",
    "metadata": {},
    "source": [
     "## 2. Dataset preparation\n",
@@ -255,13 +300,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "e492adc8",
+   "id": "c0df3892",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:06.468541Z",
-     "iopub.status.busy": "2026-08-03T20:19:06.468467Z",
-     "iopub.status.idle": "2026-08-03T20:19:06.603540Z",
-     "shell.execute_reply": "2026-08-03T20:19:06.603131Z"
+     "iopub.execute_input": "2026-08-10T23:07:37.073533Z",
+     "iopub.status.busy": "2026-08-10T23:07:37.073403Z",
+     "iopub.status.idle": "2026-08-10T23:07:37.231657Z",
+     "shell.execute_reply": "2026-08-10T23:07:37.231247Z"
     }
    },
    "outputs": [
@@ -329,13 +374,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "710e1a79",
+   "id": "d75f0b56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:06.604508Z",
-     "iopub.status.busy": "2026-08-03T20:19:06.604436Z",
-     "iopub.status.idle": "2026-08-03T20:19:06.754361Z",
-     "shell.execute_reply": "2026-08-03T20:19:06.754028Z"
+     "iopub.execute_input": "2026-08-10T23:07:37.232747Z",
+     "iopub.status.busy": "2026-08-10T23:07:37.232682Z",
+     "iopub.status.idle": "2026-08-10T23:07:37.456265Z",
+     "shell.execute_reply": "2026-08-10T23:07:37.455880Z"
     }
    },
    "outputs": [
@@ -363,7 +408,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33b9ffcf",
+   "id": "86913fe9",
    "metadata": {},
    "source": [
     "## 3. Predictive modelling - linear regression per country\n",
@@ -384,13 +429,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "b272a4cd",
+   "id": "6474abbe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:06.755412Z",
-     "iopub.status.busy": "2026-08-03T20:19:06.755354Z",
-     "iopub.status.idle": "2026-08-03T20:19:11.149096Z",
-     "shell.execute_reply": "2026-08-03T20:19:11.148534Z"
+     "iopub.execute_input": "2026-08-10T23:07:37.457443Z",
+     "iopub.status.busy": "2026-08-10T23:07:37.457355Z",
+     "iopub.status.idle": "2026-08-10T23:07:42.722280Z",
+     "shell.execute_reply": "2026-08-10T23:07:42.721808Z"
     }
    },
    "outputs": [
@@ -454,13 +499,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "cba8688d",
+   "id": "4fc27624",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:11.150926Z",
-     "iopub.status.busy": "2026-08-03T20:19:11.150773Z",
-     "iopub.status.idle": "2026-08-03T20:19:11.420666Z",
-     "shell.execute_reply": "2026-08-03T20:19:11.420269Z"
+     "iopub.execute_input": "2026-08-10T23:07:42.725086Z",
+     "iopub.status.busy": "2026-08-10T23:07:42.724978Z",
+     "iopub.status.idle": "2026-08-10T23:07:43.031155Z",
+     "shell.execute_reply": "2026-08-10T23:07:43.030707Z"
     }
    },
    "outputs": [
@@ -493,13 +538,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "6de1af7d",
+   "id": "19bc992b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:11.421721Z",
-     "iopub.status.busy": "2026-08-03T20:19:11.421659Z",
-     "iopub.status.idle": "2026-08-03T20:19:11.615602Z",
-     "shell.execute_reply": "2026-08-03T20:19:11.615208Z"
+     "iopub.execute_input": "2026-08-10T23:07:43.032352Z",
+     "iopub.status.busy": "2026-08-10T23:07:43.032277Z",
+     "iopub.status.idle": "2026-08-10T23:07:43.252246Z",
+     "shell.execute_reply": "2026-08-10T23:07:43.251848Z"
     }
    },
    "outputs": [
@@ -545,7 +590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c159f4a",
+   "id": "11733600",
    "metadata": {},
    "source": [
     "## 4. Clustering - K-Means on the most volatile country\n",
@@ -563,32 +608,32 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "ccfad4f1",
+   "id": "146c06b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:11.616798Z",
-     "iopub.status.busy": "2026-08-03T20:19:11.616711Z",
-     "iopub.status.idle": "2026-08-03T20:19:15.321868Z",
-     "shell.execute_reply": "2026-08-03T20:19:15.321454Z"
+     "iopub.execute_input": "2026-08-10T23:07:43.253435Z",
+     "iopub.status.busy": "2026-08-10T23:07:43.253354Z",
+     "iopub.status.idle": "2026-08-10T23:07:49.036655Z",
+     "shell.execute_reply": "2026-08-10T23:07:49.035060Z"
     }
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CodeCache: size=131072Kb used=40204Kb max_used=40204Kb free=90867Kb\n",
+      " bounds [0x00000001022bc000, 0x0000000104a3c000, 0x000000010a2bc000]\n",
+      " total_blobs=15665 nmethods=13876 adapters=1700\n",
+      " compilation: disabled (not enough contiguous free space left)\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
       "Java HotSpot(TM) 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.\n",
       "Java HotSpot(TM) 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CodeCache: size=131072Kb used=39400Kb max_used=39400Kb free=91671Kb\n",
-      " bounds [0x0000000106754000, 0x0000000108e04000, 0x000000010e754000]\n",
-      " total_blobs=15462 nmethods=13675 adapters=1700\n",
-      " compilation: disabled (not enough contiguous free space left)\n"
      ]
     },
     {
@@ -659,13 +704,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1a74607d",
+   "id": "edc35b42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:15.323865Z",
-     "iopub.status.busy": "2026-08-03T20:19:15.323762Z",
-     "iopub.status.idle": "2026-08-03T20:19:15.495047Z",
-     "shell.execute_reply": "2026-08-03T20:19:15.494675Z"
+     "iopub.execute_input": "2026-08-10T23:07:49.053898Z",
+     "iopub.status.busy": "2026-08-10T23:07:49.053754Z",
+     "iopub.status.idle": "2026-08-10T23:07:49.436289Z",
+     "shell.execute_reply": "2026-08-10T23:07:49.435374Z"
     }
    },
    "outputs": [
@@ -700,13 +745,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a20eaecf",
+   "id": "e1d533cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:15.496253Z",
-     "iopub.status.busy": "2026-08-03T20:19:15.496177Z",
-     "iopub.status.idle": "2026-08-03T20:19:15.613284Z",
-     "shell.execute_reply": "2026-08-03T20:19:15.612935Z"
+     "iopub.execute_input": "2026-08-10T23:07:49.438740Z",
+     "iopub.status.busy": "2026-08-10T23:07:49.438620Z",
+     "iopub.status.idle": "2026-08-10T23:07:49.788766Z",
+     "shell.execute_reply": "2026-08-10T23:07:49.788294Z"
     }
    },
    "outputs": [
@@ -755,7 +800,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab679313",
+   "id": "f1ced311",
    "metadata": {},
    "source": [
     "## 5. Graph analytics - the focal country and its neighbours\n",
@@ -773,13 +818,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "58a49fd8",
+   "id": "335fd0be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:15.614393Z",
-     "iopub.status.busy": "2026-08-03T20:19:15.614334Z",
-     "iopub.status.idle": "2026-08-03T20:19:15.835028Z",
-     "shell.execute_reply": "2026-08-03T20:19:15.834597Z"
+     "iopub.execute_input": "2026-08-10T23:07:49.800949Z",
+     "iopub.status.busy": "2026-08-10T23:07:49.800815Z",
+     "iopub.status.idle": "2026-08-10T23:07:50.050152Z",
+     "shell.execute_reply": "2026-08-10T23:07:50.049647Z"
     }
    },
    "outputs": [
@@ -863,13 +908,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "806a3fc1",
+   "id": "122b29e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:15.836067Z",
-     "iopub.status.busy": "2026-08-03T20:19:15.836012Z",
-     "iopub.status.idle": "2026-08-03T20:19:15.909973Z",
-     "shell.execute_reply": "2026-08-03T20:19:15.909601Z"
+     "iopub.execute_input": "2026-08-10T23:07:50.054262Z",
+     "iopub.status.busy": "2026-08-10T23:07:50.054065Z",
+     "iopub.status.idle": "2026-08-10T23:07:50.370699Z",
+     "shell.execute_reply": "2026-08-10T23:07:50.370232Z"
     }
    },
    "outputs": [
@@ -918,7 +963,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b27c9dbe",
+   "id": "11101f7b",
    "metadata": {},
    "source": [
     "## 6. Lead-lag analysis - who can actually be warned?\n",
@@ -942,13 +987,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "9ea829ee",
+   "id": "6320157e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:15.911038Z",
-     "iopub.status.busy": "2026-08-03T20:19:15.910974Z",
-     "iopub.status.idle": "2026-08-03T20:19:15.929082Z",
-     "shell.execute_reply": "2026-08-03T20:19:15.928768Z"
+     "iopub.execute_input": "2026-08-10T23:07:50.373219Z",
+     "iopub.status.busy": "2026-08-10T23:07:50.373089Z",
+     "iopub.status.idle": "2026-08-10T23:07:50.411550Z",
+     "shell.execute_reply": "2026-08-10T23:07:50.410411Z"
     }
    },
    "outputs": [
@@ -1010,13 +1055,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "01a4a8d7",
+   "id": "56508d3e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:15.930137Z",
-     "iopub.status.busy": "2026-08-03T20:19:15.930061Z",
-     "iopub.status.idle": "2026-08-03T20:19:16.075803Z",
-     "shell.execute_reply": "2026-08-03T20:19:16.075532Z"
+     "iopub.execute_input": "2026-08-10T23:07:50.414768Z",
+     "iopub.status.busy": "2026-08-10T23:07:50.414449Z",
+     "iopub.status.idle": "2026-08-10T23:07:50.664292Z",
+     "shell.execute_reply": "2026-08-10T23:07:50.663749Z"
     }
    },
    "outputs": [
@@ -1063,7 +1108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac2a1809",
+   "id": "178b7fd3",
    "metadata": {},
    "source": [
     "## 7. Visualisation - the story in one frame\n",
@@ -1076,13 +1121,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "b5d3e809",
+   "id": "60c5abc3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:16.076944Z",
-     "iopub.status.busy": "2026-08-03T20:19:16.076889Z",
-     "iopub.status.idle": "2026-08-03T20:19:16.336581Z",
-     "shell.execute_reply": "2026-08-03T20:19:16.336235Z"
+     "iopub.execute_input": "2026-08-10T23:07:50.665745Z",
+     "iopub.status.busy": "2026-08-10T23:07:50.665638Z",
+     "iopub.status.idle": "2026-08-10T23:07:51.307901Z",
+     "shell.execute_reply": "2026-08-10T23:07:51.306920Z"
     }
    },
    "outputs": [
@@ -1127,13 +1172,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "ca24f091",
+   "id": "20b99516",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:16.337682Z",
-     "iopub.status.busy": "2026-08-03T20:19:16.337621Z",
-     "iopub.status.idle": "2026-08-03T20:19:16.349239Z",
-     "shell.execute_reply": "2026-08-03T20:19:16.348908Z"
+     "iopub.execute_input": "2026-08-10T23:07:51.311599Z",
+     "iopub.status.busy": "2026-08-10T23:07:51.311467Z",
+     "iopub.status.idle": "2026-08-10T23:07:51.324745Z",
+     "shell.execute_reply": "2026-08-10T23:07:51.324346Z"
     }
    },
    "outputs": [
@@ -1196,7 +1241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5a23cf1",
+   "id": "f939c4de",
    "metadata": {},
    "source": [
     "## 8. Conclusion and recommendation\n",
@@ -1225,7 +1270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bf72866",
+   "id": "0fdaf348",
    "metadata": {},
    "source": [
     "## 9. Limitations\n",
@@ -1252,7 +1297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a8f54db",
+   "id": "6d402191",
    "metadata": {},
    "source": [
     "## Academic Integrity Declaration\n",
@@ -1299,7 +1344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95a57ff0",
+   "id": "e74fc199",
    "metadata": {},
    "source": [
     "## Appendix A - Glossary\n",
@@ -1331,7 +1376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e0e9748",
+   "id": "60d11495",
    "metadata": {},
    "source": [
     "## Appendix B - Analytical decision log\n",
@@ -1388,19 +1433,26 @@
     "the fix, rather than surfacing a raw traceback: missing or malformed dataset, absent Java installation,\n",
     "Spark start-up failure, an unconfigured focal country, a neighbour absent from the data, missing\n",
     "coordinates, and series too short to model or correlate. Non-fatal issues (a neighbour missing from the\n",
-    "dataset, or missing map coordinates) emit a warning and continue with the remaining countries."
+    "dataset, or missing map coordinates) emit a warning and continue with the remaining countries.\n",
+    "\n",
+    "**Google Colab.** A bare `.ipynb` opened in Colab starts with none of this repo's folders, so the local\n",
+    "path-resolution fallback in Section 0 would otherwise raise `SetupError`. Section 0 detects Colab\n",
+    "(`\"google.colab\" in sys.modules`) and self-heals instead: installs `pyspark` and OpenJDK if either is\n",
+    "missing, then downloads the same JHU CSSE file from its canonical GitHub source into a fresh working\n",
+    "folder. The downloaded file is byte-identical (verified via sha256) to the one tracked in this repo's\n",
+    "`dataset/` folder, so every downstream number is unaffected by which environment produced it."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "112e7c0d",
+   "id": "0b58cd1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T20:19:16.350280Z",
-     "iopub.status.busy": "2026-08-03T20:19:16.350223Z",
-     "iopub.status.idle": "2026-08-03T20:19:17.336541Z",
-     "shell.execute_reply": "2026-08-03T20:19:17.334736Z"
+     "iopub.execute_input": "2026-08-10T23:07:51.326715Z",
+     "iopub.status.busy": "2026-08-10T23:07:51.326585Z",
+     "iopub.status.idle": "2026-08-10T23:07:52.047785Z",
+     "shell.execute_reply": "2026-08-10T23:07:52.045983Z"
     }
    },
    "outputs": [

--- a/2026-T2/BDA/assignments/Assessment3/notebook/BDA601FariaLuis_Assessment3.ipynb
+++ b/2026-T2/BDA/assignments/Assessment3/notebook/BDA601FariaLuis_Assessment3.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "36d20791",
+   "id": "305dfecd",
    "metadata": {},
    "source": [
     "# BDA601 Assessment 3 - Model Evaluation\n",
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a554fb9b",
+   "id": "3bb07e25",
    "metadata": {},
    "source": [
     "## How to run this notebook\n",
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dbd03261",
+   "id": "ab9d8aeb",
    "metadata": {},
    "source": [
     "## 0. Setup, environment checks and Spark session\n",
@@ -77,13 +77,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9218e7e8",
+   "id": "43285036",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:31.973498Z",
-     "iopub.status.busy": "2026-08-10T23:07:31.973138Z",
-     "iopub.status.idle": "2026-08-10T23:07:34.489582Z",
-     "shell.execute_reply": "2026-08-10T23:07:34.489120Z"
+     "iopub.execute_input": "2026-08-10T23:11:45.472087Z",
+     "iopub.status.busy": "2026-08-10T23:11:45.471728Z",
+     "iopub.status.idle": "2026-08-10T23:11:46.318813Z",
+     "shell.execute_reply": "2026-08-10T23:11:46.318342Z"
     }
    },
    "outputs": [
@@ -116,10 +116,21 @@
     "        raise SetupError(message)\n",
     "\n",
     "\n",
+    "def _java_runs(home):\n",
+    "    '''A JAVA_HOME candidate is only valid if `bin/java` actually executes - a directory\n",
+    "    existing on disk is not enough (a broken or partial install still passes that check).'''\n",
+    "    java_bin = Path(home) / \"bin\" / \"java\"\n",
+    "    try:\n",
+    "        return subprocess.run([str(java_bin), \"-version\"], capture_output=True,\n",
+    "                               text=True, timeout=10).returncode == 0\n",
+    "    except (OSError, subprocess.SubprocessError):\n",
+    "        return False\n",
+    "\n",
+    "\n",
     "def find_java_home():\n",
-    "    '''Locate a Java 8/11 installation. Spark 3.5 will not start without one.'''\n",
+    "    '''Locate a working Java 8/11 installation. Spark 3.5 will not start without one.'''\n",
     "    env = os.environ.get(\"JAVA_HOME\")\n",
-    "    if env and Path(env).exists():\n",
+    "    if env and _java_runs(env):\n",
     "        return env\n",
     "    # macOS ships a helper that reports installed JVMs.\n",
     "    for version in (\"1.8\", \"11\"):\n",
@@ -130,10 +141,15 @@
     "                return found.stdout.strip()\n",
     "        except (OSError, subprocess.SubprocessError):\n",
     "            pass\n",
-    "    for candidate in (\"/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home\",\n",
-    "                      \"/usr/lib/jvm/java-11-openjdk-amd64\",\n",
-    "                      \"/usr/lib/jvm/java-8-openjdk-amd64\"):\n",
-    "        if Path(candidate).exists():\n",
+    "    candidates = [\"/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home\"]\n",
+    "    # Glob rather than a single hard-coded path: Debian/Ubuntu suffix the JVM directory by\n",
+    "    # architecture (amd64, arm64, ...), and Colab's exact image has changed over time.\n",
+    "    candidates += sorted(str(p) for p in Path(\"/usr/lib/jvm\").glob(\"java-11-openjdk-*\")) \\\n",
+    "        if Path(\"/usr/lib/jvm\").exists() else []\n",
+    "    candidates += sorted(str(p) for p in Path(\"/usr/lib/jvm\").glob(\"java-8-openjdk-*\")) \\\n",
+    "        if Path(\"/usr/lib/jvm\").exists() else []\n",
+    "    for candidate in candidates:\n",
+    "        if _java_runs(candidate):\n",
     "            return candidate\n",
     "    return None\n",
     "\n",
@@ -147,8 +163,16 @@
     "        print(\"Installing pyspark for Colab (one-off, ~20s)...\")\n",
     "        subprocess.run([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"pyspark==3.5.3\"], check=True)\n",
     "    if find_java_home() is None:\n",
-    "        print(\"Installing OpenJDK 11 for Colab (one-off, ~15s)...\")\n",
-    "        subprocess.run([\"apt-get\", \"install\", \"-y\", \"-qq\", \"openjdk-11-jdk-headless\"], check=False)\n",
+    "        # `apt-get update` first: Colab's package index can be stale enough that `install`\n",
+    "        # silently resolves nothing for a specific package without it.\n",
+    "        print(\"Installing OpenJDK 11 for Colab (one-off, ~20-40s)...\")\n",
+    "        subprocess.run([\"apt-get\", \"update\", \"-qq\"], check=False)\n",
+    "        install = subprocess.run([\"apt-get\", \"install\", \"-y\", \"-qq\", \"openjdk-11-jdk-headless\"],\n",
+    "                                 capture_output=True, text=True)\n",
+    "        if install.returncode != 0 or find_java_home() is None:\n",
+    "            print(\"Automatic Java install did not complete. If Spark still fails to start below, \"\n",
+    "                  \"run this in a new Colab cell, then re-run this cell:\\n\"\n",
+    "                  \"  !apt-get update -qq && !apt-get install -y openjdk-11-jdk-headless\")\n",
     "\n",
     "os.environ[\"PYSPARK_PYTHON\"] = sys.executable\n",
     "os.environ[\"PYSPARK_DRIVER_PYTHON\"] = sys.executable\n",
@@ -209,13 +233,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "03743d8b",
+   "id": "f3eef67c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:34.492907Z",
-     "iopub.status.busy": "2026-08-10T23:07:34.492755Z",
-     "iopub.status.idle": "2026-08-10T23:07:37.071374Z",
-     "shell.execute_reply": "2026-08-10T23:07:37.070501Z"
+     "iopub.execute_input": "2026-08-10T23:11:46.320026Z",
+     "iopub.status.busy": "2026-08-10T23:11:46.319900Z",
+     "iopub.status.idle": "2026-08-10T23:11:48.264594Z",
+     "shell.execute_reply": "2026-08-10T23:11:48.264094Z"
     }
    },
    "outputs": [
@@ -223,8 +247,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "26/08/11 09:07:36 WARN Utils: Your hostname, Luiss-MacBook-Pro.local resolves to a loopback address: 127.0.0.1; using 192.168.0.3 instead (on interface en0)\n",
-      "26/08/11 09:07:36 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n"
+      "26/08/11 09:11:47 WARN Utils: Your hostname, Luiss-MacBook-Pro.local resolves to a loopback address: 127.0.0.1; using 192.168.0.3 instead (on interface en0)\n",
+      "26/08/11 09:11:47 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n"
      ]
     },
     {
@@ -233,7 +257,7 @@
      "text": [
       "Setting default log level to \"WARN\".\n",
       "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
-      "26/08/11 09:07:36 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+      "26/08/11 09:11:47 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
      ]
     },
     {
@@ -264,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74ad5075",
+   "id": "df570cdd",
    "metadata": {},
    "source": [
     "## 1. Problem statement\n",
@@ -282,7 +306,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9404ccb3",
+   "id": "c10b525c",
    "metadata": {},
    "source": [
     "## 2. Dataset preparation\n",
@@ -300,13 +324,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "c0df3892",
+   "id": "be3ca10d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:37.073533Z",
-     "iopub.status.busy": "2026-08-10T23:07:37.073403Z",
-     "iopub.status.idle": "2026-08-10T23:07:37.231657Z",
-     "shell.execute_reply": "2026-08-10T23:07:37.231247Z"
+     "iopub.execute_input": "2026-08-10T23:11:48.266329Z",
+     "iopub.status.busy": "2026-08-10T23:11:48.266235Z",
+     "iopub.status.idle": "2026-08-10T23:11:48.431623Z",
+     "shell.execute_reply": "2026-08-10T23:11:48.431223Z"
     }
    },
    "outputs": [
@@ -374,13 +398,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d75f0b56",
+   "id": "570c2681",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:37.232747Z",
-     "iopub.status.busy": "2026-08-10T23:07:37.232682Z",
-     "iopub.status.idle": "2026-08-10T23:07:37.456265Z",
-     "shell.execute_reply": "2026-08-10T23:07:37.455880Z"
+     "iopub.execute_input": "2026-08-10T23:11:48.432605Z",
+     "iopub.status.busy": "2026-08-10T23:11:48.432542Z",
+     "iopub.status.idle": "2026-08-10T23:11:48.576602Z",
+     "shell.execute_reply": "2026-08-10T23:11:48.576286Z"
     }
    },
    "outputs": [
@@ -408,7 +432,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86913fe9",
+   "id": "d3c74180",
    "metadata": {},
    "source": [
     "## 3. Predictive modelling - linear regression per country\n",
@@ -429,16 +453,24 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "6474abbe",
+   "id": "405cb48d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:37.457443Z",
-     "iopub.status.busy": "2026-08-10T23:07:37.457355Z",
-     "iopub.status.idle": "2026-08-10T23:07:42.722280Z",
-     "shell.execute_reply": "2026-08-10T23:07:42.721808Z"
+     "iopub.execute_input": "2026-08-10T23:11:48.577870Z",
+     "iopub.status.busy": "2026-08-10T23:11:48.577808Z",
+     "iopub.status.idle": "2026-08-10T23:11:54.304247Z",
+     "shell.execute_reply": "2026-08-10T23:11:54.303656Z"
     }
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[Stage 0:>                                                          (0 + 0) / 8]\r"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -499,13 +531,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "4fc27624",
+   "id": "c3a6eeaf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:42.725086Z",
-     "iopub.status.busy": "2026-08-10T23:07:42.724978Z",
-     "iopub.status.idle": "2026-08-10T23:07:43.031155Z",
-     "shell.execute_reply": "2026-08-10T23:07:43.030707Z"
+     "iopub.execute_input": "2026-08-10T23:11:54.306814Z",
+     "iopub.status.busy": "2026-08-10T23:11:54.306726Z",
+     "iopub.status.idle": "2026-08-10T23:11:54.607936Z",
+     "shell.execute_reply": "2026-08-10T23:11:54.607513Z"
     }
    },
    "outputs": [
@@ -538,13 +570,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "19bc992b",
+   "id": "0ec9b0c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:43.032352Z",
-     "iopub.status.busy": "2026-08-10T23:07:43.032277Z",
-     "iopub.status.idle": "2026-08-10T23:07:43.252246Z",
-     "shell.execute_reply": "2026-08-10T23:07:43.251848Z"
+     "iopub.execute_input": "2026-08-10T23:11:54.609156Z",
+     "iopub.status.busy": "2026-08-10T23:11:54.609031Z",
+     "iopub.status.idle": "2026-08-10T23:11:54.840541Z",
+     "shell.execute_reply": "2026-08-10T23:11:54.840150Z"
     }
    },
    "outputs": [
@@ -590,7 +622,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11733600",
+   "id": "ab43ed8a",
    "metadata": {},
    "source": [
     "## 4. Clustering - K-Means on the most volatile country\n",
@@ -608,32 +640,32 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "146c06b8",
+   "id": "858e9a7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:43.253435Z",
-     "iopub.status.busy": "2026-08-10T23:07:43.253354Z",
-     "iopub.status.idle": "2026-08-10T23:07:49.036655Z",
-     "shell.execute_reply": "2026-08-10T23:07:49.035060Z"
+     "iopub.execute_input": "2026-08-10T23:11:54.842100Z",
+     "iopub.status.busy": "2026-08-10T23:11:54.842005Z",
+     "iopub.status.idle": "2026-08-10T23:11:59.534041Z",
+     "shell.execute_reply": "2026-08-10T23:11:59.533170Z"
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CodeCache: size=131072Kb used=40204Kb max_used=40204Kb free=90867Kb\n",
-      " bounds [0x00000001022bc000, 0x0000000104a3c000, 0x000000010a2bc000]\n",
-      " total_blobs=15665 nmethods=13876 adapters=1700\n",
-      " compilation: disabled (not enough contiguous free space left)\n"
-     ]
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
       "Java HotSpot(TM) 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.\n",
       "Java HotSpot(TM) 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CodeCache: size=131072Kb used=43757Kb max_used=43757Kb free=87314Kb\n",
+      " bounds [0x00000001020a4000, 0x0000000104ba4000, 0x000000010a0a4000]\n",
+      " total_blobs=16474 nmethods=14684 adapters=1700\n",
+      " compilation: disabled (not enough contiguous free space left)\n"
      ]
     },
     {
@@ -704,13 +736,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "edc35b42",
+   "id": "5075ca6e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:49.053898Z",
-     "iopub.status.busy": "2026-08-10T23:07:49.053754Z",
-     "iopub.status.idle": "2026-08-10T23:07:49.436289Z",
-     "shell.execute_reply": "2026-08-10T23:07:49.435374Z"
+     "iopub.execute_input": "2026-08-10T23:11:59.536810Z",
+     "iopub.status.busy": "2026-08-10T23:11:59.536670Z",
+     "iopub.status.idle": "2026-08-10T23:11:59.729326Z",
+     "shell.execute_reply": "2026-08-10T23:11:59.728916Z"
     }
    },
    "outputs": [
@@ -745,13 +777,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "e1d533cf",
+   "id": "ee875f63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:49.438740Z",
-     "iopub.status.busy": "2026-08-10T23:07:49.438620Z",
-     "iopub.status.idle": "2026-08-10T23:07:49.788766Z",
-     "shell.execute_reply": "2026-08-10T23:07:49.788294Z"
+     "iopub.execute_input": "2026-08-10T23:11:59.731553Z",
+     "iopub.status.busy": "2026-08-10T23:11:59.731473Z",
+     "iopub.status.idle": "2026-08-10T23:11:59.938419Z",
+     "shell.execute_reply": "2026-08-10T23:11:59.938091Z"
     }
    },
    "outputs": [
@@ -800,7 +832,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1ced311",
+   "id": "64050b1c",
    "metadata": {},
    "source": [
     "## 5. Graph analytics - the focal country and its neighbours\n",
@@ -818,13 +850,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "335fd0be",
+   "id": "1f85c636",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:49.800949Z",
-     "iopub.status.busy": "2026-08-10T23:07:49.800815Z",
-     "iopub.status.idle": "2026-08-10T23:07:50.050152Z",
-     "shell.execute_reply": "2026-08-10T23:07:50.049647Z"
+     "iopub.execute_input": "2026-08-10T23:11:59.940099Z",
+     "iopub.status.busy": "2026-08-10T23:11:59.940021Z",
+     "iopub.status.idle": "2026-08-10T23:12:00.125776Z",
+     "shell.execute_reply": "2026-08-10T23:12:00.125358Z"
     }
    },
    "outputs": [
@@ -832,13 +864,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Focal: US | neighbours: ['Canada', 'Mexico']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Focal: US | neighbours: ['Canada', 'Mexico']\n",
       "neighbour  corr  ci_low  ci_high  weeks\n",
       "   Canada 0.848   0.264    0.920    164\n",
       "   Mexico 0.697   0.459    0.819    164\n"
@@ -908,13 +934,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "122b29e1",
+   "id": "a4dc2ab7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:50.054262Z",
-     "iopub.status.busy": "2026-08-10T23:07:50.054065Z",
-     "iopub.status.idle": "2026-08-10T23:07:50.370699Z",
-     "shell.execute_reply": "2026-08-10T23:07:50.370232Z"
+     "iopub.execute_input": "2026-08-10T23:12:00.126972Z",
+     "iopub.status.busy": "2026-08-10T23:12:00.126894Z",
+     "iopub.status.idle": "2026-08-10T23:12:00.206261Z",
+     "shell.execute_reply": "2026-08-10T23:12:00.205786Z"
     }
    },
    "outputs": [
@@ -963,7 +989,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11101f7b",
+   "id": "ee64c82c",
    "metadata": {},
    "source": [
     "## 6. Lead-lag analysis - who can actually be warned?\n",
@@ -987,13 +1013,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "6320157e",
+   "id": "a74f3ee7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:50.373219Z",
-     "iopub.status.busy": "2026-08-10T23:07:50.373089Z",
-     "iopub.status.idle": "2026-08-10T23:07:50.411550Z",
-     "shell.execute_reply": "2026-08-10T23:07:50.410411Z"
+     "iopub.execute_input": "2026-08-10T23:12:00.207636Z",
+     "iopub.status.busy": "2026-08-10T23:12:00.207567Z",
+     "iopub.status.idle": "2026-08-10T23:12:00.225127Z",
+     "shell.execute_reply": "2026-08-10T23:12:00.224784Z"
     }
    },
    "outputs": [
@@ -1055,13 +1081,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "56508d3e",
+   "id": "c6f7a4db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:50.414768Z",
-     "iopub.status.busy": "2026-08-10T23:07:50.414449Z",
-     "iopub.status.idle": "2026-08-10T23:07:50.664292Z",
-     "shell.execute_reply": "2026-08-10T23:07:50.663749Z"
+     "iopub.execute_input": "2026-08-10T23:12:00.226252Z",
+     "iopub.status.busy": "2026-08-10T23:12:00.226189Z",
+     "iopub.status.idle": "2026-08-10T23:12:00.381671Z",
+     "shell.execute_reply": "2026-08-10T23:12:00.381311Z"
     }
    },
    "outputs": [
@@ -1108,7 +1134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "178b7fd3",
+   "id": "ba953261",
    "metadata": {},
    "source": [
     "## 7. Visualisation - the story in one frame\n",
@@ -1121,13 +1147,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "60c5abc3",
+   "id": "213dd1fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:50.665745Z",
-     "iopub.status.busy": "2026-08-10T23:07:50.665638Z",
-     "iopub.status.idle": "2026-08-10T23:07:51.307901Z",
-     "shell.execute_reply": "2026-08-10T23:07:51.306920Z"
+     "iopub.execute_input": "2026-08-10T23:12:00.383215Z",
+     "iopub.status.busy": "2026-08-10T23:12:00.383133Z",
+     "iopub.status.idle": "2026-08-10T23:12:00.670552Z",
+     "shell.execute_reply": "2026-08-10T23:12:00.670110Z"
     }
    },
    "outputs": [
@@ -1172,13 +1198,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "20b99516",
+   "id": "db42efcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:51.311599Z",
-     "iopub.status.busy": "2026-08-10T23:07:51.311467Z",
-     "iopub.status.idle": "2026-08-10T23:07:51.324745Z",
-     "shell.execute_reply": "2026-08-10T23:07:51.324346Z"
+     "iopub.execute_input": "2026-08-10T23:12:00.671862Z",
+     "iopub.status.busy": "2026-08-10T23:12:00.671761Z",
+     "iopub.status.idle": "2026-08-10T23:12:00.677585Z",
+     "shell.execute_reply": "2026-08-10T23:12:00.677238Z"
     }
    },
    "outputs": [
@@ -1241,7 +1267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f939c4de",
+   "id": "5f12a05a",
    "metadata": {},
    "source": [
     "## 8. Conclusion and recommendation\n",
@@ -1270,7 +1296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fdaf348",
+   "id": "1fbafea1",
    "metadata": {},
    "source": [
     "## 9. Limitations\n",
@@ -1297,7 +1323,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d402191",
+   "id": "b8227abf",
    "metadata": {},
    "source": [
     "## Academic Integrity Declaration\n",
@@ -1344,7 +1370,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e74fc199",
+   "id": "ffb107fb",
    "metadata": {},
    "source": [
     "## Appendix A - Glossary\n",
@@ -1376,7 +1402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60d11495",
+   "id": "7da23b77",
    "metadata": {},
    "source": [
     "## Appendix B - Analytical decision log\n",
@@ -1446,13 +1472,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "0b58cd1f",
+   "id": "bd600672",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:07:51.326715Z",
-     "iopub.status.busy": "2026-08-10T23:07:51.326585Z",
-     "iopub.status.idle": "2026-08-10T23:07:52.047785Z",
-     "shell.execute_reply": "2026-08-10T23:07:52.045983Z"
+     "iopub.execute_input": "2026-08-10T23:12:00.678750Z",
+     "iopub.status.busy": "2026-08-10T23:12:00.678689Z",
+     "iopub.status.idle": "2026-08-10T23:12:01.538482Z",
+     "shell.execute_reply": "2026-08-10T23:12:01.537076Z"
     }
    },
    "outputs": [

--- a/2026-T2/BDA/assignments/Assessment3/notebook/BDA601FariaLuis_Assessment3.ipynb
+++ b/2026-T2/BDA/assignments/Assessment3/notebook/BDA601FariaLuis_Assessment3.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5fd47ee6",
+   "id": "86fdcc61",
    "metadata": {},
    "source": [
     "# BDA601 Assessment 3 - Model Evaluation\n",
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a9eb9c5",
+   "id": "e408033f",
    "metadata": {},
    "source": [
     "## How to run this notebook\n",
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68ebdfb9",
+   "id": "ce0fceef",
    "metadata": {},
    "source": [
     "## 0. Setup, environment checks and Spark session\n",
@@ -77,13 +77,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "30fe736b",
+   "id": "74aa66c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:14:44.425790Z",
-     "iopub.status.busy": "2026-08-10T23:14:44.425637Z",
-     "iopub.status.idle": "2026-08-10T23:14:45.451135Z",
-     "shell.execute_reply": "2026-08-10T23:14:45.450583Z"
+     "iopub.execute_input": "2026-08-10T23:30:42.588132Z",
+     "iopub.status.busy": "2026-08-10T23:30:42.587842Z",
+     "iopub.status.idle": "2026-08-10T23:30:44.301692Z",
+     "shell.execute_reply": "2026-08-10T23:30:44.299187Z"
     }
    },
    "outputs": [
@@ -168,12 +168,20 @@
     "\n",
     "\n",
     "if IN_COLAB:\n",
-    "    # Colab's base image has neither pyspark nor a JVM. Both are one-off, silent installs -\n",
-    "    # this is the expected starting state there, not a misconfiguration to blame the user for.\n",
+    "    # Colab's base image ships pyspark preinstalled - but as of writing, a newer major version\n",
+    "    # (4.x) whose launcher is compiled for Java 17+, not the Java 8/11 this notebook is built\n",
+    "    # and verified against (pyspark 3.5.3, matching the local bda-spark kernel). Checking via\n",
+    "    # importlib.metadata (not `import pyspark`) avoids ever loading the wrong version into this\n",
+    "    # process before the pinned one can replace it - `pip install` is idempotent, so this is a\n",
+    "    # silent no-op on an environment that already has 3.5.3.\n",
+    "    from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PkgNotFound\n",
     "    try:\n",
-    "        import pyspark  # noqa: F401\n",
-    "    except ImportError:\n",
-    "        print(\"Installing pyspark for Colab (one-off, ~20s)...\")\n",
+    "        _pyspark_ok = _pkg_version(\"pyspark\") == \"3.5.3\"\n",
+    "    except _PkgNotFound:\n",
+    "        _pyspark_ok = False\n",
+    "    if not _pyspark_ok:\n",
+    "        print(\"Installing pyspark==3.5.3 for Colab (one-off, ~30-60s) - \"\n",
+    "              \"a different pyspark version was preinstalled...\")\n",
     "        subprocess.run([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"pyspark==3.5.3\"], check=True)\n",
     "    if find_java_home() is None:\n",
     "        # `apt-get update` first: Colab's package index can be stale enough that `install`\n",
@@ -246,13 +254,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "31274c79",
+   "id": "5f91ce69",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:14:45.458853Z",
-     "iopub.status.busy": "2026-08-10T23:14:45.458485Z",
-     "iopub.status.idle": "2026-08-10T23:14:48.215021Z",
-     "shell.execute_reply": "2026-08-10T23:14:48.214385Z"
+     "iopub.execute_input": "2026-08-10T23:30:44.316899Z",
+     "iopub.status.busy": "2026-08-10T23:30:44.316448Z",
+     "iopub.status.idle": "2026-08-10T23:30:47.205002Z",
+     "shell.execute_reply": "2026-08-10T23:30:47.204424Z"
     }
    },
    "outputs": [
@@ -260,8 +268,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "26/08/11 09:14:46 WARN Utils: Your hostname, Luiss-MacBook-Pro.local resolves to a loopback address: 127.0.0.1; using 192.168.0.3 instead (on interface en0)\n",
-      "26/08/11 09:14:46 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n"
+      "26/08/11 09:30:45 WARN Utils: Your hostname, Luiss-MacBook-Pro.local resolves to a loopback address: 127.0.0.1; using 192.168.0.3 instead (on interface en0)\n",
+      "26/08/11 09:30:45 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n"
      ]
     },
     {
@@ -269,14 +277,8 @@
      "output_type": "stream",
      "text": [
       "Setting default log level to \"WARN\".\n",
-      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "26/08/11 09:14:47 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
+      "26/08/11 09:30:46 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
      ]
     },
     {
@@ -307,7 +309,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8137d6f3",
+   "id": "fae4fdc3",
    "metadata": {},
    "source": [
     "## 1. Problem statement\n",
@@ -325,7 +327,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccfe3164",
+   "id": "5a033007",
    "metadata": {},
    "source": [
     "## 2. Dataset preparation\n",
@@ -343,13 +345,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "5c368296",
+   "id": "5083c9ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:14:48.216944Z",
-     "iopub.status.busy": "2026-08-10T23:14:48.216830Z",
-     "iopub.status.idle": "2026-08-10T23:14:48.534855Z",
-     "shell.execute_reply": "2026-08-10T23:14:48.534358Z"
+     "iopub.execute_input": "2026-08-10T23:30:47.213481Z",
+     "iopub.status.busy": "2026-08-10T23:30:47.213346Z",
+     "iopub.status.idle": "2026-08-10T23:30:47.454015Z",
+     "shell.execute_reply": "2026-08-10T23:30:47.453623Z"
     }
    },
    "outputs": [
@@ -417,13 +419,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9e07c388",
+   "id": "a6051444",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:14:48.539483Z",
-     "iopub.status.busy": "2026-08-10T23:14:48.539361Z",
-     "iopub.status.idle": "2026-08-10T23:14:48.699412Z",
-     "shell.execute_reply": "2026-08-10T23:14:48.698995Z"
+     "iopub.execute_input": "2026-08-10T23:30:47.455320Z",
+     "iopub.status.busy": "2026-08-10T23:30:47.455246Z",
+     "iopub.status.idle": "2026-08-10T23:30:47.693691Z",
+     "shell.execute_reply": "2026-08-10T23:30:47.693195Z"
     }
    },
    "outputs": [
@@ -451,7 +453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3095d230",
+   "id": "3ef27061",
    "metadata": {},
    "source": [
     "## 3. Predictive modelling - linear regression per country\n",
@@ -472,13 +474,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "5501a2df",
+   "id": "24940052",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:14:48.700629Z",
-     "iopub.status.busy": "2026-08-10T23:14:48.700550Z",
-     "iopub.status.idle": "2026-08-10T23:14:58.230984Z",
-     "shell.execute_reply": "2026-08-10T23:14:58.229394Z"
+     "iopub.execute_input": "2026-08-10T23:30:47.694959Z",
+     "iopub.status.busy": "2026-08-10T23:30:47.694877Z",
+     "iopub.status.idle": "2026-08-10T23:30:55.600687Z",
+     "shell.execute_reply": "2026-08-10T23:30:55.599669Z"
     }
    },
    "outputs": [
@@ -494,16 +496,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "                                                                                \r"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "[Stage 2:>                                                          (0 + 8) / 8]\r",
       "\r",
       "                                                                                \r"
      ]
@@ -552,13 +544,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "fdf6f32b",
+   "id": "b084fc74",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:14:58.246014Z",
-     "iopub.status.busy": "2026-08-10T23:14:58.245844Z",
-     "iopub.status.idle": "2026-08-10T23:14:58.666558Z",
-     "shell.execute_reply": "2026-08-10T23:14:58.666147Z"
+     "iopub.execute_input": "2026-08-10T23:30:55.613935Z",
+     "iopub.status.busy": "2026-08-10T23:30:55.613780Z",
+     "iopub.status.idle": "2026-08-10T23:30:55.945108Z",
+     "shell.execute_reply": "2026-08-10T23:30:55.944580Z"
     }
    },
    "outputs": [
@@ -591,13 +583,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "aad18d16",
+   "id": "4f9e35f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:14:58.669489Z",
-     "iopub.status.busy": "2026-08-10T23:14:58.669393Z",
-     "iopub.status.idle": "2026-08-10T23:14:58.960792Z",
-     "shell.execute_reply": "2026-08-10T23:14:58.960434Z"
+     "iopub.execute_input": "2026-08-10T23:30:55.947638Z",
+     "iopub.status.busy": "2026-08-10T23:30:55.947517Z",
+     "iopub.status.idle": "2026-08-10T23:30:56.164262Z",
+     "shell.execute_reply": "2026-08-10T23:30:56.163904Z"
     }
    },
    "outputs": [
@@ -643,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fd1d768",
+   "id": "b66bfad2",
    "metadata": {},
    "source": [
     "## 4. Clustering - K-Means on the most volatile country\n",
@@ -661,13 +653,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "585fdcfc",
+   "id": "23b431dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:14:58.962354Z",
-     "iopub.status.busy": "2026-08-10T23:14:58.962266Z",
-     "iopub.status.idle": "2026-08-10T23:15:04.548723Z",
-     "shell.execute_reply": "2026-08-10T23:15:04.548220Z"
+     "iopub.execute_input": "2026-08-10T23:30:56.166598Z",
+     "iopub.status.busy": "2026-08-10T23:30:56.166505Z",
+     "iopub.status.idle": "2026-08-10T23:31:01.351457Z",
+     "shell.execute_reply": "2026-08-10T23:31:01.350469Z"
     }
    },
    "outputs": [
@@ -683,9 +675,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CodeCache: size=131072Kb used=37631Kb max_used=37656Kb free=93440Kb\n",
-      " bounds [0x00000001029c0000, 0x0000000104ec0000, 0x000000010a9c0000]\n",
-      " total_blobs=14819 nmethods=13030 adapters=1700\n",
+      "CodeCache: size=131072Kb used=42443Kb max_used=42443Kb free=88629Kb\n",
+      " bounds [0x0000000104020000, 0x00000001069d0000, 0x000000010c020000]\n",
+      " total_blobs=16316 nmethods=14526 adapters=1700\n",
       " compilation: disabled (not enough contiguous free space left)\n"
      ]
     },
@@ -757,13 +749,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "8b64f9c4",
+   "id": "a15ffd45",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:15:04.552024Z",
-     "iopub.status.busy": "2026-08-10T23:15:04.551875Z",
-     "iopub.status.idle": "2026-08-10T23:15:04.749692Z",
-     "shell.execute_reply": "2026-08-10T23:15:04.749249Z"
+     "iopub.execute_input": "2026-08-10T23:31:01.360531Z",
+     "iopub.status.busy": "2026-08-10T23:31:01.360124Z",
+     "iopub.status.idle": "2026-08-10T23:31:01.633904Z",
+     "shell.execute_reply": "2026-08-10T23:31:01.633078Z"
     }
    },
    "outputs": [
@@ -798,13 +790,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "9f33fb07",
+   "id": "b3402c70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:15:04.750911Z",
-     "iopub.status.busy": "2026-08-10T23:15:04.750823Z",
-     "iopub.status.idle": "2026-08-10T23:15:05.054499Z",
-     "shell.execute_reply": "2026-08-10T23:15:05.054081Z"
+     "iopub.execute_input": "2026-08-10T23:31:01.635411Z",
+     "iopub.status.busy": "2026-08-10T23:31:01.635280Z",
+     "iopub.status.idle": "2026-08-10T23:31:01.845945Z",
+     "shell.execute_reply": "2026-08-10T23:31:01.845588Z"
     }
    },
    "outputs": [
@@ -853,7 +845,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eaaee4fc",
+   "id": "8df2bd7d",
    "metadata": {},
    "source": [
     "## 5. Graph analytics - the focal country and its neighbours\n",
@@ -871,13 +863,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "c9e4f61d",
+   "id": "9705f9d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:15:05.055860Z",
-     "iopub.status.busy": "2026-08-10T23:15:05.055784Z",
-     "iopub.status.idle": "2026-08-10T23:15:05.306741Z",
-     "shell.execute_reply": "2026-08-10T23:15:05.306342Z"
+     "iopub.execute_input": "2026-08-10T23:31:01.847502Z",
+     "iopub.status.busy": "2026-08-10T23:31:01.847429Z",
+     "iopub.status.idle": "2026-08-10T23:31:02.042299Z",
+     "shell.execute_reply": "2026-08-10T23:31:02.041902Z"
     }
    },
    "outputs": [
@@ -885,23 +877,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Focal: US | neighbours: ['Canada', 'Mexico']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Focal: US | neighbours: ['Canada', 'Mexico']\n",
       "neighbour  corr  ci_low  ci_high  weeks\n",
       "   Canada 0.848   0.264    0.920    164\n",
-      "   Mexico 0.697   0.459    0.819    164"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "   Mexico 0.697   0.459    0.819    164\n"
      ]
     }
    ],
@@ -968,13 +947,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "a821d161",
+   "id": "728d3e95",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:15:05.308186Z",
-     "iopub.status.busy": "2026-08-10T23:15:05.308099Z",
-     "iopub.status.idle": "2026-08-10T23:15:05.403271Z",
-     "shell.execute_reply": "2026-08-10T23:15:05.402679Z"
+     "iopub.execute_input": "2026-08-10T23:31:02.043699Z",
+     "iopub.status.busy": "2026-08-10T23:31:02.043630Z",
+     "iopub.status.idle": "2026-08-10T23:31:02.133417Z",
+     "shell.execute_reply": "2026-08-10T23:31:02.132958Z"
     }
    },
    "outputs": [
@@ -1023,7 +1002,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03c54094",
+   "id": "ce4edf09",
    "metadata": {},
    "source": [
     "## 6. Lead-lag analysis - who can actually be warned?\n",
@@ -1047,13 +1026,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "e9164fee",
+   "id": "007092e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:15:05.404549Z",
-     "iopub.status.busy": "2026-08-10T23:15:05.404457Z",
-     "iopub.status.idle": "2026-08-10T23:15:05.425725Z",
-     "shell.execute_reply": "2026-08-10T23:15:05.425331Z"
+     "iopub.execute_input": "2026-08-10T23:31:02.135038Z",
+     "iopub.status.busy": "2026-08-10T23:31:02.134942Z",
+     "iopub.status.idle": "2026-08-10T23:31:02.154421Z",
+     "shell.execute_reply": "2026-08-10T23:31:02.154027Z"
     }
    },
    "outputs": [
@@ -1115,13 +1094,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "3825d38d",
+   "id": "e7ef38c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:15:05.426805Z",
-     "iopub.status.busy": "2026-08-10T23:15:05.426738Z",
-     "iopub.status.idle": "2026-08-10T23:15:05.848173Z",
-     "shell.execute_reply": "2026-08-10T23:15:05.847762Z"
+     "iopub.execute_input": "2026-08-10T23:31:02.155930Z",
+     "iopub.status.busy": "2026-08-10T23:31:02.155869Z",
+     "iopub.status.idle": "2026-08-10T23:31:02.325648Z",
+     "shell.execute_reply": "2026-08-10T23:31:02.325257Z"
     }
    },
    "outputs": [
@@ -1168,7 +1147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a910242b",
+   "id": "edb253ac",
    "metadata": {},
    "source": [
     "## 7. Visualisation - the story in one frame\n",
@@ -1181,13 +1160,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "800d1eb5",
+   "id": "afb2f172",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:15:05.849801Z",
-     "iopub.status.busy": "2026-08-10T23:15:05.849696Z",
-     "iopub.status.idle": "2026-08-10T23:15:06.134123Z",
-     "shell.execute_reply": "2026-08-10T23:15:06.133590Z"
+     "iopub.execute_input": "2026-08-10T23:31:02.326861Z",
+     "iopub.status.busy": "2026-08-10T23:31:02.326772Z",
+     "iopub.status.idle": "2026-08-10T23:31:02.618918Z",
+     "shell.execute_reply": "2026-08-10T23:31:02.618419Z"
     }
    },
    "outputs": [
@@ -1232,13 +1211,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "5f088a22",
+   "id": "181ed845",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:15:06.135289Z",
-     "iopub.status.busy": "2026-08-10T23:15:06.135202Z",
-     "iopub.status.idle": "2026-08-10T23:15:06.141029Z",
-     "shell.execute_reply": "2026-08-10T23:15:06.140613Z"
+     "iopub.execute_input": "2026-08-10T23:31:02.623329Z",
+     "iopub.status.busy": "2026-08-10T23:31:02.623179Z",
+     "iopub.status.idle": "2026-08-10T23:31:02.630571Z",
+     "shell.execute_reply": "2026-08-10T23:31:02.630016Z"
     }
    },
    "outputs": [
@@ -1301,7 +1280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea115af0",
+   "id": "f0551f74",
    "metadata": {},
    "source": [
     "## 8. Conclusion and recommendation\n",
@@ -1330,7 +1309,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d5d8dc7",
+   "id": "03786df5",
    "metadata": {},
    "source": [
     "## 9. Limitations\n",
@@ -1357,7 +1336,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6cbc1542",
+   "id": "bf45e8c3",
    "metadata": {},
    "source": [
     "## Academic Integrity Declaration\n",
@@ -1404,7 +1383,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "337ca8a2",
+   "id": "df664d44",
    "metadata": {},
    "source": [
     "## Appendix A - Glossary\n",
@@ -1436,7 +1415,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45a5e2cb",
+   "id": "5aa6d22e",
    "metadata": {},
    "source": [
     "## Appendix B - Analytical decision log\n",
@@ -1506,13 +1485,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "db54aeac",
+   "id": "0334d0d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:15:06.142730Z",
-     "iopub.status.busy": "2026-08-10T23:15:06.142644Z",
-     "iopub.status.idle": "2026-08-10T23:15:06.650542Z",
-     "shell.execute_reply": "2026-08-10T23:15:06.649374Z"
+     "iopub.execute_input": "2026-08-10T23:31:02.632173Z",
+     "iopub.status.busy": "2026-08-10T23:31:02.632078Z",
+     "iopub.status.idle": "2026-08-10T23:31:03.355850Z",
+     "shell.execute_reply": "2026-08-10T23:31:03.354443Z"
     }
    },
    "outputs": [

--- a/2026-T2/BDA/assignments/Assessment3/notebook/build_nb.py
+++ b/2026-T2/BDA/assignments/Assessment3/notebook/build_nb.py
@@ -86,10 +86,21 @@ def require(condition, message):
         raise SetupError(message)
 
 
+def _java_runs(home):
+    '''A JAVA_HOME candidate is only valid if `bin/java` actually executes - a directory
+    existing on disk is not enough (a broken or partial install still passes that check).'''
+    java_bin = Path(home) / "bin" / "java"
+    try:
+        return subprocess.run([str(java_bin), "-version"], capture_output=True,
+                               text=True, timeout=10).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
 def find_java_home():
-    '''Locate a Java 8/11 installation. Spark 3.5 will not start without one.'''
+    '''Locate a working Java 8/11 installation. Spark 3.5 will not start without one.'''
     env = os.environ.get("JAVA_HOME")
-    if env and Path(env).exists():
+    if env and _java_runs(env):
         return env
     # macOS ships a helper that reports installed JVMs.
     for version in ("1.8", "11"):
@@ -100,10 +111,15 @@ def find_java_home():
                 return found.stdout.strip()
         except (OSError, subprocess.SubprocessError):
             pass
-    for candidate in ("/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home",
-                      "/usr/lib/jvm/java-11-openjdk-amd64",
-                      "/usr/lib/jvm/java-8-openjdk-amd64"):
-        if Path(candidate).exists():
+    candidates = ["/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home"]
+    # Glob rather than a single hard-coded path: Debian/Ubuntu suffix the JVM directory by
+    # architecture (amd64, arm64, ...), and Colab's exact image has changed over time.
+    candidates += sorted(str(p) for p in Path("/usr/lib/jvm").glob("java-11-openjdk-*")) \
+        if Path("/usr/lib/jvm").exists() else []
+    candidates += sorted(str(p) for p in Path("/usr/lib/jvm").glob("java-8-openjdk-*")) \
+        if Path("/usr/lib/jvm").exists() else []
+    for candidate in candidates:
+        if _java_runs(candidate):
             return candidate
     return None
 
@@ -117,8 +133,16 @@ if IN_COLAB:
         print("Installing pyspark for Colab (one-off, ~20s)...")
         subprocess.run([sys.executable, "-m", "pip", "install", "-q", "pyspark==3.5.3"], check=True)
     if find_java_home() is None:
-        print("Installing OpenJDK 11 for Colab (one-off, ~15s)...")
-        subprocess.run(["apt-get", "install", "-y", "-qq", "openjdk-11-jdk-headless"], check=False)
+        # `apt-get update` first: Colab's package index can be stale enough that `install`
+        # silently resolves nothing for a specific package without it.
+        print("Installing OpenJDK 11 for Colab (one-off, ~20-40s)...")
+        subprocess.run(["apt-get", "update", "-qq"], check=False)
+        install = subprocess.run(["apt-get", "install", "-y", "-qq", "openjdk-11-jdk-headless"],
+                                 capture_output=True, text=True)
+        if install.returncode != 0 or find_java_home() is None:
+            print("Automatic Java install did not complete. If Spark still fails to start below, "
+                  "run this in a new Colab cell, then re-run this cell:\n"
+                  "  !apt-get update -qq && !apt-get install -y openjdk-11-jdk-headless")
 
 os.environ["PYSPARK_PYTHON"] = sys.executable
 os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable

--- a/2026-T2/BDA/assignments/Assessment3/notebook/build_nb.py
+++ b/2026-T2/BDA/assignments/Assessment3/notebook/build_nb.py
@@ -138,12 +138,20 @@ def find_java_home():
 
 
 if IN_COLAB:
-    # Colab's base image has neither pyspark nor a JVM. Both are one-off, silent installs -
-    # this is the expected starting state there, not a misconfiguration to blame the user for.
+    # Colab's base image ships pyspark preinstalled - but as of writing, a newer major version
+    # (4.x) whose launcher is compiled for Java 17+, not the Java 8/11 this notebook is built
+    # and verified against (pyspark 3.5.3, matching the local bda-spark kernel). Checking via
+    # importlib.metadata (not `import pyspark`) avoids ever loading the wrong version into this
+    # process before the pinned one can replace it - `pip install` is idempotent, so this is a
+    # silent no-op on an environment that already has 3.5.3.
+    from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PkgNotFound
     try:
-        import pyspark  # noqa: F401
-    except ImportError:
-        print("Installing pyspark for Colab (one-off, ~20s)...")
+        _pyspark_ok = _pkg_version("pyspark") == "3.5.3"
+    except _PkgNotFound:
+        _pyspark_ok = False
+    if not _pyspark_ok:
+        print("Installing pyspark==3.5.3 for Colab (one-off, ~30-60s) - "
+              "a different pyspark version was preinstalled...")
         subprocess.run([sys.executable, "-m", "pip", "install", "-q", "pyspark==3.5.3"], check=True)
     if find_java_home() is None:
         # `apt-get update` first: Colab's package index can be stale enough that `install`

--- a/2026-T2/BDA/assignments/Assessment3/notebook/build_nb.py
+++ b/2026-T2/BDA/assignments/Assessment3/notebook/build_nb.py
@@ -11,13 +11,21 @@ def code(s): cells.append(nbf.v4.new_code_cell(s))
 
 # ---------------------------------------------------------------- Title
 md(r"""# BDA601 Assessment 3 - Model Evaluation
-### COVID-19 analytics: regression, clustering and graph analytics on the Johns Hopkins time series
 
-| Item | Detail |
+## COVID-19 Analytics: Regression, Clustering and Graph Analytics on the Johns Hopkins Time Series
+
+*BDA601 Assessment 3 - Model Evaluation*
+
+Torrens University Australia
+
+- **Student:** Luis Guilherme de Barros Andrade Faria - A00187785
+- **Subject:** Big Data and Analytics (BDA601)
+- **Lecturer:** Dr. Chen Zhan
+- **Assessment:** 3
+- **Date:** August 2026
+
+| Field | Scope |
 |---|---|
-| Student | Luis Faria |
-| Subject | BDA601 - Big Data and Analytics |
-| Assessment | Assessment 3 - Model Evaluation (40%) |
 | Dataset | JHU CSSE confirmed-cases global time series (22 Jan 2020 - 9 Mar 2023) |
 | Engine | Apache Spark MLlib (`pyspark.ml`) for regression + K-Means; networkx for graph |
 | Deliverables | Source code (this notebook) + video presentation + PDF slides |
@@ -34,7 +42,7 @@ md(r"""## How to run this notebook
 needed: `JAVA_HOME` is detected automatically in Section 0, and every path is resolved relative to
 this notebook.
 
-**Steps**
+**Steps (local)**
 
 1. Place `time_series_covid19_confirmed_global.csv` in the `dataset/` folder next to this notebook's
    parent (that is, `Assessment3/dataset/`). The file is the *confirmed cases* global time series from
@@ -42,6 +50,12 @@ this notebook.
    <https://data.humdata.org/dataset/novel-coronavirus-2019-ncov-cases>.
 2. Run all cells top to bottom (`Kernel -> Restart & Run All`). Total runtime is about 1-2 minutes.
 3. Outputs are written automatically to `outputs/figures/*.png` and `outputs/metrics.json`.
+
+**Google Colab** - if this notebook is opened on its own (no `dataset/` folder present), Section 0
+detects Colab and self-configures: it `pip install`s `pyspark`, `apt-get install`s OpenJDK if no JVM is
+present, and downloads the same JHU CSSE file from its canonical GitHub source (byte-identical to the
+copy in this repo's `dataset/` folder) into a fresh working folder under `/content`. No manual upload
+or setup step is required in Colab either.
 
 **If something goes wrong** - each stage validates its inputs and raises a message that names the
 problem and the fix (missing dataset, missing Java, unknown country, insufficient overlap). Read the
@@ -58,6 +72,8 @@ code(r"""import os, sys, json, subprocess, warnings
 from pathlib import Path
 
 warnings.filterwarnings("ignore")
+
+IN_COLAB = "google.colab" in sys.modules
 
 
 class SetupError(RuntimeError):
@@ -92,6 +108,18 @@ def find_java_home():
     return None
 
 
+if IN_COLAB:
+    # Colab's base image has neither pyspark nor a JVM. Both are one-off, silent installs -
+    # this is the expected starting state there, not a misconfiguration to blame the user for.
+    try:
+        import pyspark  # noqa: F401
+    except ImportError:
+        print("Installing pyspark for Colab (one-off, ~20s)...")
+        subprocess.run([sys.executable, "-m", "pip", "install", "-q", "pyspark==3.5.3"], check=True)
+    if find_java_home() is None:
+        print("Installing OpenJDK 11 for Colab (one-off, ~15s)...")
+        subprocess.run(["apt-get", "install", "-y", "-qq", "openjdk-11-jdk-headless"], check=False)
+
 os.environ["PYSPARK_PYTHON"] = sys.executable
 os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable
 
@@ -118,6 +146,23 @@ ASSESS = CWD if (CWD / "dataset").exists() else CWD.parent
 DATA = ASSESS / "dataset" / "time_series_covid19_confirmed_global.csv"
 OUT_DIR = ASSESS / "outputs"
 FIG_DIR = OUT_DIR / "figures"
+
+if not DATA.exists() and IN_COLAB:
+    # A bare notebook opened in Colab has none of this repo's folders - the local fallback
+    # above resolves to nowhere sensible. Recreate the expected layout under /content and
+    # fetch the same file from its canonical GitHub source (verified byte-identical, via
+    # sha256, to the copy tracked in this repo's dataset/ folder).
+    print("Dataset not found locally - downloading JHU CSSE confirmed-cases series for Colab...")
+    import urllib.request
+    ASSESS = Path("/content/BDA601_Assessment3")
+    DATA = ASSESS / "dataset" / "time_series_covid19_confirmed_global.csv"
+    OUT_DIR = ASSESS / "outputs"
+    FIG_DIR = OUT_DIR / "figures"
+    DATA.parent.mkdir(parents=True, exist_ok=True)
+    urllib.request.urlretrieve(
+        "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/"
+        "csse_covid_19_time_series/time_series_covid19_confirmed_global.csv", DATA)
+
 FIG_DIR.mkdir(parents=True, exist_ok=True)
 
 require(DATA.exists(),
@@ -795,7 +840,14 @@ problem on a single feature, so it has no stochastic component.
 the fix, rather than surfacing a raw traceback: missing or malformed dataset, absent Java installation,
 Spark start-up failure, an unconfigured focal country, a neighbour absent from the data, missing
 coordinates, and series too short to model or correlate. Non-fatal issues (a neighbour missing from the
-dataset, or missing map coordinates) emit a warning and continue with the remaining countries.""")
+dataset, or missing map coordinates) emit a warning and continue with the remaining countries.
+
+**Google Colab.** A bare `.ipynb` opened in Colab starts with none of this repo's folders, so the local
+path-resolution fallback in Section 0 would otherwise raise `SetupError`. Section 0 detects Colab
+(`"google.colab" in sys.modules`) and self-heals instead: installs `pyspark` and OpenJDK if either is
+missing, then downloads the same JHU CSSE file from its canonical GitHub source into a fresh working
+folder. The downloaded file is byte-identical (verified via sha256) to the one tracked in this repo's
+`dataset/` folder, so every downstream number is unaffected by which environment produced it.""")
 
 code(r"""spark.stop(); print("Spark stopped.")""")
 

--- a/2026-T2/BDA/assignments/Assessment3/notebook/build_nb.py
+++ b/2026-T2/BDA/assignments/Assessment3/notebook/build_nb.py
@@ -68,7 +68,7 @@ Spark workers are pinned to this Python kernel (driver == executor) so there is 
 mismatch, `JAVA_HOME` is discovered rather than hard-coded, and the seed is fixed for reproducibility.
 Each check fails with an actionable message instead of an obscure traceback.""")
 
-code(r"""import os, sys, json, subprocess, warnings
+code(r"""import os, sys, json, re, subprocess, warnings
 from pathlib import Path
 
 warnings.filterwarnings("ignore")
@@ -86,21 +86,34 @@ def require(condition, message):
         raise SetupError(message)
 
 
-def _java_runs(home):
-    '''A JAVA_HOME candidate is only valid if `bin/java` actually executes - a directory
-    existing on disk is not enough (a broken or partial install still passes that check).'''
+def _java_version_ok(home):
+    '''A JAVA_HOME candidate is only valid if `bin/java` runs AND reports version 8 or 11 -
+    Spark 3.5 supports neither older nor newer JDKs, and a directory merely existing on disk,
+    or a working-but-wrong-version `java`, both pass a shallower check and fail later with an
+    opaque JAVA_GATEWAY_EXITED when Spark actually tries to start.'''
     java_bin = Path(home) / "bin" / "java"
     try:
-        return subprocess.run([str(java_bin), "-version"], capture_output=True,
-                               text=True, timeout=10).returncode == 0
+        result = subprocess.run([str(java_bin), "-version"], capture_output=True,
+                                text=True, timeout=10)
     except (OSError, subprocess.SubprocessError):
         return False
+    if result.returncode != 0:
+        return False
+    # `java -version` writes to stderr by long-standing convention (stdout on some vendors).
+    output = result.stderr or result.stdout
+    match = re.search(r'version "(\d+)(?:\.(\d+))?', output)
+    if not match:
+        return False
+    major = int(match.group(1))
+    if major == 1:  # legacy "1.8.0_xxx" scheme used by Java 8 and earlier
+        major = int(match.group(2)) if match.group(2) else 0
+    return major in (8, 11)
 
 
 def find_java_home():
     '''Locate a working Java 8/11 installation. Spark 3.5 will not start without one.'''
     env = os.environ.get("JAVA_HOME")
-    if env and _java_runs(env):
+    if env and _java_version_ok(env):
         return env
     # macOS ships a helper that reports installed JVMs.
     for version in ("1.8", "11"):
@@ -119,7 +132,7 @@ def find_java_home():
     candidates += sorted(str(p) for p in Path("/usr/lib/jvm").glob("java-8-openjdk-*")) \
         if Path("/usr/lib/jvm").exists() else []
     for candidate in candidates:
-        if _java_runs(candidate):
+        if _java_version_ok(candidate):
             return candidate
     return None
 


### PR DESCRIPTION
## Summary
- Section 0 detects Google Colab (`"google.colab" in sys.modules`) and self-heals when the local `dataset/` folder isn't present: installs `pyspark`/OpenJDK if missing, downloads the JHU CSSE file from its canonical GitHub source into a fresh `/content` working folder.
- Downloaded file verified byte-identical (sha256) to the copy tracked in this repo's `dataset/` folder - no risk to any reported number regardless of which environment produced it.
- Title block reformatted to match the MLN601 A3 notebook's style: student name + number, subject, lecturer, assessment, date.

## Why
User opened the standalone `.ipynb` in Colab and hit `SetupError: Dataset not found at /dataset/...` - the local path-resolution fallback (`CWD.parent`) has nowhere sensible to land when none of the repo's folders exist. Given the marker may do the same, this closes that failure mode instead of just documenting it.

## Verification
- [x] Notebook rebuilt and re-executed locally (`bda-spark` kernel), zero errors
- [x] `metrics.json` diffed before/after: byte-identical - confirms the Colab-only code path is dormant on a normal local run
- [x] Downloaded-file checksum matches local `dataset/` copy exactly

Relates #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Colab support with automatic environment detection and setup.
  * Automatically installs required PySpark and Java components when needed.
  * Downloads the required dataset when it is not available locally.

* **Documentation**
  * Updated run instructions, setup guidance, dataset information, and troubleshooting notes.
  * Clarified fallback behavior and non-fatal setup warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->